### PR TITLE
Extend `Config` with new options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Implement support for `Config::max_elements_to_parse` in `Readability::parse`.
+- Implement support for `Config::disable_json_ld` in `Readability::parse`.
+
 ### Fixed
 
 - Improve parsing of article's title, byline and excerpt.
 - Improve parsing of `dir` attribute.
+- Fix the internal behavior of `Readability::clean_classes` when `Config::classes_to_preserve` is empty.
 
 
 ## [0.1.1] - 2024-12-18

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -581,7 +581,6 @@ fn handle_top_candidate(tc: &Node, article_content: &Node) {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,6 @@ pub enum ReadabilityError {
     BadDocumentURL(#[from] url::ParseError),
     #[error("failed to grab the article")]
     GrabFailed,
+    #[error("too many elements ({0} > {1}) in the documents to parse")]
+    TooManyElements(usize, usize),
 }

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -1075,24 +1075,24 @@ mod tests {
     #[test]
     fn test_max_elements() {
         let contents = include_str!("../test-pages/rustwiki_2024.html");
-        let cfg = Config {
-            max_elements_to_parse: 10,
-            ..Default::default()
-        };
-        let mut readability = Readability::new(contents, None, Some(cfg)).unwrap();
+        // each element represent a test parameters, where 0 is max_elements_to_parse, 1 is want_err
+        let tests = [(10, true), (0, false), (10000, false)];
 
-        let res = readability.parse();
-        assert!(matches!(
-            res.err().unwrap(),
-            ReadabilityError::TooManyElements(_, 10)
-        ));
-
-        let cfg = Config {
-            max_elements_to_parse: 0,
-            ..Default::default()
-        };
-        let mut readability = Readability::new(contents, None, Some(cfg)).unwrap();
-        let res = readability.parse();
-        assert!(res.is_ok());
+        for (max_elements_to_parse, want_err) in tests {
+            let cfg = Config {
+                max_elements_to_parse,
+                ..Default::default()
+            };
+            let mut readability = Readability::new(contents, None, Some(cfg)).unwrap();
+            let res = readability.parse();
+            if want_err {
+                assert!(matches!(
+                    res.err().unwrap(),
+                    ReadabilityError::TooManyElements(_, _)
+                ));
+            } else {
+                assert!(res.is_ok());
+            }
+        }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -91,12 +91,6 @@ where
         article.published_time, expected.published_time,
         "published_time does not match expected"
     );
-    assert_eq!(
-        article.lang, expected.lang,
-        "lang does not match expected"
-    );
-    assert_eq!(
-        article.dir, expected.dir,
-        "dirs does not match expected"
-    );
+    assert_eq!(article.lang, expected.lang, "lang does not match expected");
+    assert_eq!(article.dir, expected.dir, "dirs does not match expected");
 }


### PR DESCRIPTION
- Implement support for `Config::max_elements_to_parse` in `Readability::parse`.
- Implement support for `Config::disable_json_ld` in `Readability::parse`.
- Fix the internal behavior of `Readability::clean_classes` when `Config::classes_to_preserve` is empty.
 