### PR TITLE
Extend dom_smoothie_cli functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- - Implemented a CLI tool (`dom_smoothie_cli`) for demonstration purposes.
+
 ### Fixed
 - `Article.text_content` accidentally contained text content of the original document. Now it contains only the text content of the article after processing.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dom_smoothie",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/dom_smoothie_cli/Cargo.toml
+++ b/dom_smoothie_cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dom_smoothie_cli"
 version = "0.1.0"
 edition = "2021"
-description = "A reference cli for dom_smoothie"
+description = "A reference implementation of a CLI tool for the `dom_smoothie`"
 authors = ["niklak <morgenpurple@gmail.com>"]
 
 

--- a/dom_smoothie_cli/Cargo.toml
+++ b/dom_smoothie_cli/Cargo.toml
@@ -9,3 +9,5 @@ authors = ["niklak <morgenpurple@gmail.com>"]
 [dependencies]
 dom_smoothie = {path = "./.."}
 clap = {version = "4.5.23", features = ["derive"]}
+serde = {version = "1.0", features = ["derive"]}
+serde_json = {version = "1.0"}

--- a/dom_smoothie_cli/src/main.rs
+++ b/dom_smoothie_cli/src/main.rs
@@ -1,3 +1,18 @@
+//! This is a reference implementation of a CLI tool for the `dom_smoothie` crate.
+//!
+//! The tool processes an HTML document using `dom_smoothie::Readability` to extract
+//! relevant content and metadata. It accepts an input HTML file and outputs the
+//! parsed article content as both HTML and plain text, along with metadata in JSON format.
+//!
+//! ## Usage
+//! ```bash
+//! dom_smoothie_cli --input path/to/input.html --output path/to/output/dir
+//! ```
+//!
+//! If the `--output` argument is omitted, the results will be saved in the same directory
+//! as the input file. An optional `--document-url` parameter can be provided to enhance
+//! parsing accuracy by specifying the base document URL.
+
 use std::error::Error;
 use std::{fs, path::PathBuf};
 

--- a/dom_smoothie_cli/src/main.rs
+++ b/dom_smoothie_cli/src/main.rs
@@ -2,7 +2,8 @@ use std::error::Error;
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
-use dom_smoothie::Readability;
+use dom_smoothie::{Readability, Article};
+
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -18,10 +19,41 @@ struct Cli {
     document_url: Option<String>,
 }
 
+
+/// This struct represents the metadata from the [`dom_smoothie::Article`]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
+struct Metadata {
+    title: String,
+    byline: Option<String>,
+    excerpt: Option<String>,
+    site_name: Option<String>,
+    published_time: Option<String>,
+    modified_time: Option<String>,
+    lang: Option<String>,
+    url: Option<String>,
+    dir: Option<String>,
+}
+
+impl From<&Article> for Metadata {
+    fn from(value: &Article) -> Self {
+        Self {
+            title: value.title.clone(),
+            byline: value.byline.clone(),
+            excerpt: value.excerpt.clone(),
+            site_name: value.site_name.clone(),
+            published_time: value.published_time.clone(),
+            modified_time: value.modified_time.clone(),
+            lang: value.lang.clone(),
+            url: value.url.clone(),
+            dir: value.dir.clone(),
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let mut cli = Cli::parse();
 
-    let input_path_buf = cli.input.clone();
+    let input_path_buf = cli.input.with_extension("");
     let Some(input_fn) = input_path_buf.file_name() else {
         return Err("invalid input path".into());
     };
@@ -34,7 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let document_url = cli.document_url.as_deref();
 
     let mut ra = Readability::new(contents, document_url, None)?;
-    let res = ra.parse()?;
+    let article = ra.parse()?;
 
     let Some(output_path) = cli.output else {
         unreachable!();
@@ -44,6 +76,22 @@ fn main() -> Result<(), Box<dyn Error>> {
         .clone()
         .join(format!("{}_result.html", input_fn.to_string_lossy()));
 
-    fs::write(result_html_path, res.content.as_bytes())?;
+    fs::write(result_html_path, article.content.as_bytes())?;
+
+    let result_text_path: PathBuf = output_path
+        .clone()
+        .join(format!("{}_result.txt", input_fn.to_string_lossy()));
+
+    fs::write(result_text_path, article.text_content.as_bytes())?;
+
+    let metadata = Metadata::from(&article);
+    let metadata_content = serde_json::to_string_pretty(&metadata)?;
+
+    let meta_path: PathBuf = output_path
+        .clone()
+        .join(format!("{}_metadata.json", input_fn.to_string_lossy()));
+
+    fs::write(meta_path, metadata_content)?;
+
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ pub(crate) static DEFAULT_N_TOP_CANDIDATES: usize = 5;
 pub(crate) static DEFAULT_CHAR_THRESHOLD: usize = 500;
 
 /// Configuration options for [`crate::Readability`]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Set to `true` to keep all classes in the document
     pub keep_classes: bool,


### PR DESCRIPTION
The cli tool now dumps not only html content, but also text content and metadata.