### PR TITLE
Added `Readability::with_document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - Implemented `is_probably_readable` function. 
 A quick-and-dirty way of figuring out if the contents of a given document are suitable for processing with `Readability`.
 - Implemented `Readability::is_probably_readable`. This method calls the above function but uses its internal document (`dom_query::Document`).
+- Implemented `Readability::with_document` method, which allows to create a new `Readability` instance with external `dom_query::Document`.
+
+### Changed
+- Changed visibility of `get_text_density`, `normalize_spaces`, and `link_density` to `pub(crate)` since they are used internally only.
 
 ### Fixed
 - `Article.text_content` accidentally contained text content of the original document. Now it contains only the text content of the article after processing.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -91,7 +91,7 @@ where
     }
 }
 
-pub fn get_text_density(node: &Node, selector: &str) -> f32 {
+pub(crate) fn get_text_density(node: &Node, selector: &str) -> f32 {
     let text_length = normalize_spaces(&node.text()).chars().count() as f32;
     if text_length == 0.0 {
         return 0.0;
@@ -101,11 +101,11 @@ pub fn get_text_density(node: &Node, selector: &str) -> f32 {
     children_length / text_length
 }
 
-pub fn normalize_spaces(text: &str) -> String {
+pub(crate) fn normalize_spaces(text: &str) -> String {
     text.split_whitespace().collect::<Vec<&str>>().join(" ")
 }
 
-pub fn link_density(node: &Node) -> f32 {
+pub(crate) fn link_density(node: &Node) -> f32 {
     let text_length: f32 = normalize_spaces(&node.text()).chars().count() as f32;
     if text_length == 0.0 {
         return 0.0;

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -151,6 +151,29 @@ impl Readability {
         document_url: Option<&str>,
         cfg: Option<Config>,
     ) -> Result<Self, ReadabilityError> {
+        Self::with_document(Document::from(html), document_url, cfg)
+    }
+
+    /// Create a new `Readability` instance with a `dom_query::Document`
+    ///
+    /// # Arguments
+    ///
+    /// - `document` -- a `dom_query::Document` instance
+    /// - `document_url` -- a base URL of the page
+    /// - `cfg` -- an optional `Config` instance
+    ///
+    /// # Returns
+    ///
+    /// A new [`Readability`] instance
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReadabilityError::BadDocumentURL`] if `document_url` is not a valid URL
+    pub fn with_document(
+        document: dom_query::Document,
+        document_url: Option<&str>,
+        cfg: Option<Config>,
+    ) -> Result<Self, ReadabilityError> {
         let doc_url = if let Some(u) = document_url {
             Some(Url::parse(u)?)
         } else {
@@ -158,7 +181,7 @@ impl Readability {
         };
 
         Ok(Self {
-            doc: Document::from(html),
+            doc: document,
             doc_url,
             config: cfg.unwrap_or_default(),
         })


### PR DESCRIPTION
- Implemented `Readability::with_document` method, which allows to create a new `Readability` instance with external `dom_query::Document`.
- Changed visibility of `get_text_density`, `normalize_spaces`, and `link_density` to `pub(crate)` since they are used internally only.
