### PR TITLE
Revising base_uri extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## Changed
 - Reduced the number of regex checks since they can be replaced with `contains` checks.
+- Updated the dependencies.
+- Internal code change: use `dom_query::Document::base_uri` to extract the base uri instead of `dom_query::Matcher`. 
 
 
 ## [0.3.0] - 2025-01-08

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36ad8fe49e1234652c9e62472a8429c46d03af5e4d230edf499fd352907786"
+checksum = "688b93023aba6768721b48ec5588308e45ac42d788c6dd974d1c2b9a1d04ea29"
 dependencies = [
  "cssparser",
  "foldhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,9 @@ rust-version = "1.65"
 exclude = [".*", "test-pages"]
 
 [dependencies]
-dom_query = {version = "0.11.0"}
+dom_query = {version = "0.12.0"}
 tendril = {version = "0.4.3"}
 once_cell = { version = "1" }
-
 regex = {version = "1.11.1"}
 serde = {version = "1.0", features = ["derive"]}
 gjson = {version = "0.8.1"}

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -35,7 +35,6 @@ pub(crate) static MATCHER_A: Lazy<Matcher> = lazy_matcher!("a");
 pub(crate) static MATCHER_BR_HR: Lazy<Matcher> = lazy_matcher!("br,hr");
 pub(crate) static MATCHER_SOURCES: Lazy<Matcher> =
     lazy_matcher!("img,picture,figure,video,audio,sources");
-pub(crate) static MATCHER_BASE: Lazy<Matcher> = lazy_matcher!("base[href]");
 pub(crate) static MATCHER_P: Lazy<Matcher> = lazy_matcher!("p");
 pub(crate) static MATCHER_EMBEDS: Lazy<Matcher> = lazy_matcher!("object,embed,iframe");
 

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -1140,4 +1140,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_base_uri() {
+        let contents = r#"<!DOCTYPE>
+        <html>
+            <head>
+                <base href="https://example.com/">
+                <title>Test</title>
+            </head>
+            <body>
+            </body>
+        </html>"#;
+        let readability = Readability::from(contents);
+        let base_url = readability.parse_base_url();
+        assert_eq!(base_url.unwrap().as_str(), "https://example.com/");
+    }
 }

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -461,11 +461,13 @@ impl Readability {
 
         self.prepare();
 
-        let base_url = self.parse_base_url();
         let Some(doc) = self.grab_article(&mut metadata) else {
             return Err(ReadabilityError::GrabFailed);
         };
 
+        // Getting a base uri from the Readability.document, 
+        // which wasn't changed after the grabbing the article
+        let base_url = self.parse_base_url();
         self.post_process_content(&doc, base_url);
 
         // If we haven't found an excerpt in the article's metadata, use the article's
@@ -473,7 +475,8 @@ impl Readability {
         // the article's content.
 
         if metadata.excerpt.is_none() {
-            // TODO: Although this matches readability.js, the procedure is far from perfect and requires improvement.
+            // TODO: Although this matches readability.js, 
+            // the procedure is far from perfect and requires improvement.
             metadata.excerpt = extract_excerpt(&doc)
         }
 
@@ -877,16 +880,14 @@ impl Readability {
     }
 
     fn parse_base_url(&self) -> Option<url::Url> {
-        let sel = self.doc.select_single_matcher(&MATCHER_BASE);
-        if sel.is_empty() {
-            self.doc_url.clone()
-        } else {
-            let href = sel.attr("href")?;
-            if let Some(doc_url) = self.doc_url.clone() {
-                doc_url.join(&href).ok()
-            } else {
-                url::Url::parse(&href).ok()
-            }
+        let Some(base_uri) = self.doc.base_uri() else {
+            return self.doc_url.clone();
+        };
+
+        if let Some(doc_url) = self.doc_url.clone() {
+            doc_url.join(&base_uri).ok()
+        }else {
+            url::Url::parse(&base_uri).ok()
         }
     }
 


### PR DESCRIPTION
- Updated the dependencies.
- Internal code change: use `dom_query::Document::base_uri` to extract the base uri instead of `dom_query::Matcher`. 