### PR TITLE
Implemened  optional `serde` feature support

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run clippy
-      run: cargo clippy --verbose --all-targets -- -D warnings
+      run: cargo clippy --verbose --all-targets --all-features -- -D warnings
     - name: Install cargo audit
       uses: taiki-e/install-action@cargo-audit
     - name: Run audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Build
       run: cargo build --verbose --all
     - name: Run tests
-      run: cargo test --verbose --all-targets
+      run: cargo test --verbose --all-targets --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+- Implemented a `serde` optional crate feature, enabling `serde::Serialize` and `serde::Deserialize` traits for `Article`, `Metadata`, and `Config` structures. 
+
 ## Changed
 - Reduced the number of regex checks since they can be replaced with `contains` checks.
 - Updated the dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dom_query = {version = "0.12.0"}
 tendril = {version = "0.4.3"}
 once_cell = { version = "1" }
 regex = {version = "1.11.1"}
-serde = {version = "1.0", features = ["derive"]}
+serde = {version = "1.0", features = ["derive"], optional = true}
 gjson = {version = "0.8.1"}
 html-escape = "0.2.13"
 flagset = "0.4.6"
@@ -28,6 +28,10 @@ phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 serde_json = {version = "1.0"}
+serde = {version = "1.0", features = ["derive"]}
+
+[features]
+serde = ["dep:serde"]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     
     // Parse only the title without extracting the full content.
     let title: tendril::Tendril<tendril::fmt::UTF8> = readability.get_article_title();
-    assert_eq!(title, " Rust (programming language) - Wikipedia".into());
+    assert_eq!(title, "Rust (programming language) - Wikipedia".into());
     
     // However, this title may differ from `metadata.title`,
     // as `metadata.title` first attempts to extract the title from the metadata

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ pub(crate) static DEFAULT_CHAR_THRESHOLD: usize = 500;
 
 /// Configuration options for [`crate::Readability`]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config {
     /// Set to `true` to keep all classes in the document
     pub keep_classes: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ mod readability;
 mod readable;
 mod score;
 
+#[cfg(feature = "serde")]
+mod serde_helpers;
+
 pub use config::Config;
 pub use readability::Article;
 pub use readability::Metadata;

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -12,13 +12,28 @@ use crate::ReadabilityError;
 
 /// This struct represents the content of the article
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Article {
     /// The title
     pub title: String,
     /// The author
     pub byline: Option<String>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "crate::serde_helpers::serialize_str_tendril",
+            deserialize_with = "crate::serde_helpers::deserialize_str_tendril"
+        )
+    )]
     /// The relevant HTML content
     pub content: StrTendril,
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "crate::serde_helpers::serialize_str_tendril",
+            deserialize_with = "crate::serde_helpers::deserialize_str_tendril"
+        )
+    )]
     /// The relevant text content
     pub text_content: StrTendril,
     /// The text length
@@ -44,8 +59,9 @@ pub struct Article {
 }
 
 /// This struct represents the metadata extracted from the document
-#[derive(Debug, Default, Clone, serde::Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Metadata {
     pub title: String,
     pub byline: Option<String>,
@@ -1080,6 +1096,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_parse_json_ld() {
         let contents = include_str!("../test-pages/ok/aclu/source.html");
         let ra = Readability::from(contents);

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -12,6 +12,6 @@ pub fn deserialize_str_tendril<'de, D>(deserializer: D) -> Result<StrTendril, D:
 where
     D: Deserializer<'de>,
 {
-    let s: &str = serde::Deserialize::deserialize(deserializer)?;
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
     Ok(StrTendril::from(s))
 }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -1,0 +1,17 @@
+use serde::{Serializer, Deserializer};
+use tendril::StrTendril;
+
+pub fn serialize_str_tendril<S>(value: &StrTendril, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(value.as_ref())
+}
+
+pub fn deserialize_str_tendril<'de, D>(deserializer: D) -> Result<StrTendril, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &str = serde::Deserialize::deserialize(deserializer)?;
+    Ok(StrTendril::from(s))
+}

--- a/tests/readability.rs
+++ b/tests/readability.rs
@@ -12,3 +12,18 @@ fn table_test_readability() {
         test_readability(p.unwrap().path(), Some("http://fakehost/test/"));
     }
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_serde() {
+    let contents = include_str!("../test-pages/ok/base-url-base-element-relative/source.html");
+    let document_url = Some("http://fakehost/test/");
+    let mut ra = dom_smoothie::Readability::new(contents, document_url, None).unwrap();
+    let article = ra.parse().unwrap();
+    let article_json = serde_json::to_string(&article);
+    assert!(article_json.is_ok());
+
+    let article_json = article_json.unwrap();
+    let article_copy: dom_smoothie::Article = serde_json::from_str(&article_json).unwrap();
+    assert_eq!(article.content, article_copy.content);
+}


### PR DESCRIPTION
- Implemented a `serde` optional crate feature, enabling `serde::Serialize` and `serde::Deserialize` traits for `Article`, `Metadata`, and `Config` structures. 
