### PR TITLE
src/readability.rs: revised `Readability::is_probably_readable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - Updated the dependencies.
 - Internal code change: use `dom_query::Document::base_uri` to extract the base uri instead of `dom_query::Matcher`. 
 - Updated the code (Byline extraction and JSON-LD parsing) to align with Mozilla's recent updates to the Readability library ([118f015](https://github.com/mozilla/readability/commit/118f01538e167218bd86ffd493bd3466aec4870a)).
+- **Breaking:** Revised `Readability::is_probably_readable` method: it now uses `Config::readable_min_score` and `Config::readable_min_content_length` from the instance configuration instead of accepting arguments.
 
 ## [0.3.0] - 2025-01-08
 

--- a/README.md
+++ b/README.md
@@ -157,20 +157,25 @@ fn main() -> Result<(), Box<dyn Error>> {
 ```rust
 use std::error::Error;
 
-use dom_smoothie::{Article, Readability};
+use dom_smoothie::{Article, Readability, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let html = include_str!("../test-pages/rustwiki_2024.html");
+    // you can specify optional parameters for `Readability::is_probably_readable`.
+    let cfg = Config{
+        readable_min_score: 20.0,
+        readable_min_content_length: 140,
+        ..Default::default()
+    };
 
-    let mut readability = Readability::new(html, None, None)?;
+    let mut readability = Readability::new(html, None,  Some(cfg))?;
 
     // There is a way to perform a quick check to determine 
     // if the document is readable before cleaning and parsing it.
-    // After calling `Readability::parse`, it may show different results,
+    // After calling `Readability::parse`, it may show different results, 
     // but calling it after parsing would be nonsensical.
 
-    // You can specify content's min_score and min_content_length.
-    if readability.is_probably_readable(Some(20.0), Some(140)) {
+if readability.is_probably_readable() {
         let article: Article = readability.parse()?;
         println!("{:<15} {}", "Title:", article.title);
         println!("{:<15} {:?}", "Byline:", article.byline);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use crate::glob::{MIN_CONTENT_LENGTH, MIN_SCORE};
+
 pub(crate) static DEFAULT_N_TOP_CANDIDATES: usize = 5;
 pub(crate) static DEFAULT_CHAR_THRESHOLD: usize = 500;
 
@@ -17,6 +19,12 @@ pub struct Config {
     pub n_top_candidates: usize,
     /// Character threshold for content extraction
     pub char_threshold: usize,
+    /// The minimum score required for the document to be considered readable. Defaults to 20.0.
+    /// Used only for [`crate::Readability::is_probably_readable`].
+    pub readable_min_score: f32,
+    /// The minimum content length required for the document to be considered readable. Defaults to 140.
+    /// Used only for [`crate::Readability::is_probably_readable`].
+    pub readable_min_content_length: usize,
 }
 
 impl Default for Config {
@@ -28,6 +36,8 @@ impl Default for Config {
             disable_json_ld: false,
             n_top_candidates: DEFAULT_N_TOP_CANDIDATES,
             char_threshold: DEFAULT_CHAR_THRESHOLD,
+            readable_min_score: MIN_SCORE,
+            readable_min_content_length: MIN_CONTENT_LENGTH,
         }
     }
 }

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -969,20 +969,15 @@ impl Readability {
     ///
     /// Must be called before `Readability::parse` because it cleans the document and changes its structure.
     ///
-    /// # Arguments
-    ///
-    /// * `min_score` - The minimum score required for the document to be considered readable. Defaults to 20.0.
-    /// * `min_content_length` - The minimum content length required for the document to be considered readable. Defaults to 140.
-    ///
     /// # Returns
     ///
     /// True if the document is readable, false otherwise.
-    pub fn is_probably_readable(
-        &self,
-        min_score: Option<f32>,
-        min_content_length: Option<usize>,
-    ) -> bool {
-        is_probably_readable(&self.doc, min_score, min_content_length)
+    pub fn is_probably_readable(&self) -> bool {
+        is_probably_readable(
+            &self.doc,
+            Some(self.config.readable_min_score),
+            Some(self.config.readable_min_content_length),
+        )
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -79,7 +79,7 @@ where
     };
     let mut r = Readability::new(source_contents, host, Some(cfg)).unwrap();
 
-    let readable = r.is_probably_readable(None, None);
+    let readable = r.is_probably_readable();
 
     let article = r.parse().unwrap();
 


### PR DESCRIPTION
- **Breaking:** Revised `Readability::is_probably_readable` method: it now uses `Config::readable_min_score` and `Config::readable_min_content_length` from the instance configuration instead of accepting arguments.