### PR TITLE
src/readability.rs: skipping orphaned parents for now due to lack of …

### DIFF
--- a/src/readability.rs
+++ b/src/readability.rs
@@ -1051,7 +1051,7 @@ fn simplify_nested_elements(root_sel: &Selection) {
 
     for node in only_sel.nodes().iter().rev() {
         let Some(parent) = node.parent() else {
-            unreachable!();
+            continue;
         };
         for attr in parent.attrs() {
             node.set_attr(&attr.name.local, &attr.value);


### PR DESCRIPTION
src/readability.rs: skipping orphaned parents for now due to lack of test data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in readability processing to prevent potential runtime panics
  - Enhanced code robustness when processing nested document elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->