### PR TITLE
Fixed incorrect ancestor assignment for elements beyond the body element

### DIFF
--- a/src/grab.rs
+++ b/src/grab.rs
@@ -364,6 +364,10 @@ fn score_elements<'a>(
             };
             ancestor_score += content_score as f32 / score_divider;
             set_node_score(ancestor, ancestor_score);
+
+            if ancestor.is("body") {
+                break;
+            }
         }
     }
 

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -27,3 +27,20 @@ fn test_skip_body_ancestor() {
 }
 
 
+#[test]
+fn test_skip_body_ancestor_fragment() {
+    let contents = r#"
+    <div>
+        <p><a class="button" href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+    </div>
+    "#;
+
+    let mut ra = Readability::new(contents, None, None).unwrap();
+    let res = ra.parse().unwrap();
+    let expected: String = r#"<div id="readability-page-1" class="page"><div>
+        <p><a href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+        </div></div>"#.split_whitespace().collect();
+    let got: String = res.content.split_whitespace().collect();
+    assert_eq!(got, expected);
+}
+

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -1,0 +1,29 @@
+use dom_smoothie::Readability;
+
+#[test]
+fn test_skip_body_ancestor() {
+    let contents = r#"
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta charset="utf-8">
+            <title>Some Title</title>
+            <link rel="stylesheet" href="style.css">
+        </head>
+        <body>
+            <p><a class="button" href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+        </body>
+    </html>
+        "#;
+
+    let mut ra = Readability::new(contents, None, None).unwrap();
+    let res = ra.parse().unwrap();
+    let expected: String = r#"<div id="readability-page-1" class="page">
+        <p><a href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+        </div>"#.split_whitespace().collect();
+    let got: String = res.content.split_whitespace().collect();
+    assert_eq!(got, expected);
+}
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added two new test cases to validate parsing behavior for HTML documents with button links
	- Verified link preservation within different HTML structures
	- Ensured correct parsing of HTML fragments with nested elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->