### PR TITLE
Revise document filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - **Breaking** Revised document filtering. Since most of the filtering is now separated from extracting elements for scoring, there is a higher chance of assigning `Metadata.title` if it was empty before grabbing the article. The same applies to `Metadata.byline`, which previously could incorrectly assign a commentator as the article's author or leave it missing altogether. In the `mozilla/readability` test pages, I've encountered cases where this happened because `Readability` failed to extract readable content on the first iteration.
 - If Metadata.byline was assigned while grabbing the article, it will be normalized (no new lines or trailing spaces).
 
-## [0.4.0] - 2025-01-08
+## [0.4.0] - 2025-01-21
 
 ### Added
 - Implemented a `serde` optional crate feature, enabling `serde::Serialize` and `serde::Deserialize` traits for `Article`, `Metadata`, and `Config` structures. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - Changed the `Readability::grab_article` method implementation to retain only the best attempt among failed attempts, instead of keeping all of them until the exit.
 - Internal code optimizations aimed to reduce execution time.
 - **Breaking** Revised document filtering. Since most of the filtering is now separated from extracting elements for scoring, there is a higher chance of assigning `Metadata.title` if it was empty before grabbing the article. The same applies to `Metadata.byline`, which previously could incorrectly assign a commentator as the article's author or leave it missing altogether. In the `mozilla/readability` test pages, I've encountered cases where this happened because `Readability` failed to extract readable content on the first iteration.
-I'm sure it's better to keep metadata parsing separate from article scoring.
 - If Metadata.byline was assigned while grabbing the article, it will be normalized (no new lines or trailing spaces).
 
 ## [0.4.0] - 2025-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - Introducing the `Config::text_mode`: this mode determines whether the text is formatted or not. The default is `TextMode::Raw`, which is completely compatible with previous versions of this crate.
 
 ### Changed
- - Changed the `Readability::grab_article` method implementation to retain only the best attempt among failed attempts, instead of keeping all of them until the exit.
- - Internal code optimizations aimed to reduce execution time.
+- Changed the `Readability::grab_article` method implementation to retain only the best attempt among failed attempts, instead of keeping all of them until the exit.
+- Internal code optimizations aimed to reduce execution time.
+- **Breaking** Revised document filtering. Since most of the filtering is now separated from extracting elements for scoring, there is a higher chance of assigning `Metadata.title` if it was empty before grabbing the article. The same applies to `Metadata.byline`, which previously could incorrectly assign a commentator as the article's author or leave it missing altogether. In the `mozilla/readability` test pages, I've encountered cases where this happened because `Readability` failed to extract readable content on the first iteration.
+I'm sure it's better to keep metadata parsing separate from article scoring.
+- If Metadata.byline was assigned while grabbing the article, it will be normalized (no new lines or trailing spaces).
 
 ## [0.4.0] - 2025-01-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scopeguard"
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-segmentation"

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -199,12 +199,12 @@ fn pre_filter_document(root_node: &NodeRef, metadata: &mut Metadata) {
                 .nodes()
                 .first()
             {
-                normalize_spaces(&item_prop_name.text())
+                item_prop_name.text()
             } else {
-                normalize_spaces(&node.text())
+                node.text()
             };
 
-            metadata.byline = Some(byline);
+            metadata.byline = Some(normalize_spaces(&byline));
             nodes_to_remove.insert(node.id);
             continue;
         }

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -292,7 +292,6 @@ fn div_into_p(node: &NodeRef) {
                     break;
                 }
             }
-            //elements_to_score.push(p.clone());
             p_node = None;
         }
         child_node = next_sibling;

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -43,30 +43,29 @@ impl Readability {
             if let Some(ref article_node) = article_node {
                 metadata.dir = get_dir_attr(article_node);
                 let text_length = normalized_char_count(&article_node.text());
-                if text_length < self.config.char_threshold {
-                    if let Some((_, best_text_length)) = best_attempt {
-                        if text_length > best_text_length {
-                            best_attempt = Some((doc, text_length));
-                        }
-                    } else {
-                        best_attempt = Some((doc, text_length));
-                    }
-
-                    if flags.contains(GrabFlags::StripUnlikelys) {
-                        flags -= GrabFlags::StripUnlikelys;
-                    } else if flags.contains(GrabFlags::WeightClasses) {
-                        flags -= GrabFlags::WeightClasses;
-                    } else if flags.contains(GrabFlags::CleanConditionally) {
-                        flags -= GrabFlags::CleanConditionally;
-                    } else {
-                        // No luck after removing flags,
-                        // just return the longest text we found during the different loops
-                        let (best_doc, _) = best_attempt?;
-                        return Some(best_doc);
-                    }
-                } else {
+                if text_length >= self.config.char_threshold {
                     return Some(doc);
                 }
+
+                if let Some((_, best_text_length)) = best_attempt {
+                    if text_length > best_text_length {
+                        best_attempt = Some((doc, text_length));
+                    }
+                } else {
+                    best_attempt = Some((doc, text_length));
+                }
+            }
+            if flags.contains(GrabFlags::StripUnlikelys) {
+                flags -= GrabFlags::StripUnlikelys;
+            } else if flags.contains(GrabFlags::WeightClasses) {
+                flags -= GrabFlags::WeightClasses;
+            } else if flags.contains(GrabFlags::CleanConditionally) {
+                flags -= GrabFlags::CleanConditionally;
+            } else {
+                // No luck after removing flags,
+                // just return the longest text we found during the different loops
+                let (best_doc, _) = best_attempt?;
+                return Some(best_doc);
             }
         }
     }

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -266,7 +266,7 @@ fn is_unlikely_candidate(node: &NodeRef, match_string: &str) -> bool {
     true
 }
 
-fn div_into_p<'a>(node: &'a NodeRef) {
+fn div_into_p(node: &NodeRef) {
     // Turn all divs that don't have children block level elements into p's
     let tree = node.tree;
     // Put phrasing content into paragraphs.
@@ -671,7 +671,7 @@ fn collect_elements_to_score<'a>(root_node: &'a NodeRef, strip_unlikely: bool) -
     }
     elements_id_to_score
         .iter()
-        .map(|n| NodeRef::new(*n, &tree))
+        .map(|n| NodeRef::new(*n, tree))
         .collect()
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -125,14 +125,17 @@ pub(crate) fn normalize_spaces(text: &str) -> String {
 
 pub(crate) fn normalized_char_count(text: &str) -> usize {
     let mut char_count = 0;
-    let mut iter = text.split_whitespace();
+    let mut last_was_whitespace = true;
 
-    if let Some(first) = iter.next() {
-        char_count += first.chars().count();
-        for word in iter {
-            // whitespace between words
+    for c in text.chars() {
+        if c.is_whitespace() {
+            last_was_whitespace = true;
+        } else {
+            if !last_was_whitespace {
+                char_count += 1;
+            }
             char_count += 1;
-            char_count += word.chars().count();
+            last_was_whitespace = false;
         }
     }
     char_count

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -125,19 +125,25 @@ pub(crate) fn normalize_spaces(text: &str) -> String {
 
 pub(crate) fn normalized_char_count(text: &str) -> usize {
     let mut char_count = 0;
-    let mut last_was_whitespace = true;
+    let mut prev_was_whitespace = true;
 
     for c in text.chars() {
         if c.is_whitespace() {
-            last_was_whitespace = true;
-        } else {
-            if !last_was_whitespace {
-                char_count += 1;
+            if prev_was_whitespace {
+                continue;
             }
-            char_count += 1;
-            last_was_whitespace = false;
+            prev_was_whitespace = true;
+        } else {
+            prev_was_whitespace = false;
         }
+
+        char_count += 1;
     }
+
+    if prev_was_whitespace && char_count > 0 {
+        char_count -= 1;
+    }
+
     char_count
 }
 

--- a/src/prep_article.rs
+++ b/src/prep_article.rs
@@ -532,5 +532,7 @@ fn is_loading_word(text: &str) -> bool {
 
 fn contains_share_elements(value: &str) -> bool {
     let lower_value = value.to_lowercase();
-    lower_value.split([' ', '_']).any(|word| SHARE_WORDS.contains(word))
+    lower_value
+        .split([' ', '_'])
+        .any(|word| SHARE_WORDS.contains(word))
 }

--- a/test-pages/ok/engadget/expected.html
+++ b/test-pages/ok/engadget/expected.html
@@ -36,7 +36,9 @@
                 </ul>
             </div>
         </div>
-        <p>As promised, the Xbox One X is the most powerful game console ever. In practice, though, it really just puts Microsoft on equal footing with Sony’s PlayStation 4 Pro. 4K/HDR enhanced games look great, but it’s lack of VR is disappointing in 2017.</p>
+        <div>
+            <p>As promised, the Xbox One X is the most powerful game console ever. In practice, though, it really just puts Microsoft on equal footing with Sony’s PlayStation 4 Pro. 4K/HDR enhanced games look great, but it’s lack of VR is disappointing in 2017.</p>
+        </div>
     </div>
     <div>
         <div>

--- a/test-pages/ok/lwn-1/expected-metadata.json
+++ b/test-pages/ok/lwn-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "LWN.net Weekly Edition for March 26, 2015 [LWN.net]",
-  "byline": "By Nathan Willis\n                                            March 25, 2015",
+  "byline": "By Nathan Willis March 25, 2015",
   "dir": null,
   "excerpt": "The Arduino has been one of the biggest success stories of the open-hardware movement, but that success does not protect it from internal conflict. In recent months, two of the project's founders have come into conflict about the direction of future efforts—and that conflict has turned into a legal dispute about who owns the rights to the Arduino trademark.",
   "siteName": null,

--- a/test-pages/ok/tmz-1/expected.html
+++ b/test-pages/ok/tmz-1/expected.html
@@ -1,6 +1,7 @@
 <div id="readability-page-1" class="page">
     <div id="post-2015_02_26_lupita-nyongo-pearl-dress-stolen-oscars">
         <p>
+        <h2>Lupita Nyong'o</h2>
         <h4>$150K Pearl Oscar Dress ... STOLEN!!!!</h4>
         </p>
         <h5> 2/26/2015 7:11 AM PST BY TMZ STAFF </h5>

--- a/test-pages/readability/blogger/expected-metadata.json
+++ b/test-pages/readability/blogger/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Open Verilog flow for Silego GreenPak4 programmable logic devices",
-  "byline": null,
+  "byline": "Andrew Zonenberg",
   "dir": "ltr",
   "excerpt": "I've written a couple of posts in the past few months but they were all for the blog at work  so I figured I'm long overdue for one on Silic...",
   "siteName": null,

--- a/test-pages/readability/buzzfeed-1/expected-metadata.json
+++ b/test-pages/readability/buzzfeed-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Student Dies After Diet Pills She Bought Online \"Burned Her Up From Within\"",
-  "byline": null,
+  "byline": "Mark Di Stefano BuzzFeed News Reporter",
   "dir": null,
   "lang": "en",
   "excerpt": "An inquest into Eloise Parry's death has been adjourned until July.",

--- a/test-pages/readability/google-sre-book-1/expected-metadata.json
+++ b/test-pages/readability/google-sre-book-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Google - Site Reliability Engineering",
-  "byline": "Written by Rob Ewaschuk\n                            Edited by Betsy Beyer",
+  "byline": "Written by Rob Ewaschuk Edited by Betsy Beyer",
   "dir": null,
   "lang": "en",
   "excerpt": "Google’s SRE teams have some basic principles and best practices for building successful monitoring and alerting systems. This chapter offers guidelines for what issues should interrupt a human via a page, and how to deal with issues that aren’t serious enough to trigger a page.",

--- a/test-pages/readability/iab-1/expected-metadata.json
+++ b/test-pages/readability/iab-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Getting LEAN with Digital Ad UX | IAB",
-  "byline": "By\n\t\t\tScott Cunningham",
+  "byline": "By Scott Cunningham",
   "dir": null,
   "lang": "en-US",
   "excerpt": "We messed up. As technologists, tasked with delivering content and services to users, we lost track of the user experience. Twenty years ago we saw an explosion of websites, built by developers around the world, providing all forms of content. This was the beginning of an age of enlightenment, the intersection of content and technology. … Continued",

--- a/test-pages/readability/liberation-1/expected-metadata.json
+++ b/test-pages/readability/liberation-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Un troisième Français mort dans le séisme au Népal",
-  "byline": "Par Sébastien Farcis",
+  "byline": "AFP",
   "dir": null,
   "lang": "fr",
   "excerpt": "Laurent Fabius a accueilli jeudi matin à Roissy un premier avion spécial ramenant des rescapés.",

--- a/test-pages/readability/links-in-tables/expected-metadata.json
+++ b/test-pages/readability/links-in-tables/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Saving Data: Reducing the size of App Updates by 65%",
-  "byline": null,
+  "byline": "Posted by Android Developers",
   "dir": "ltr",
   "excerpt": "Posted by Andrew Hayden, Software Engineer on Google Play    Android users are downloading tens of billions of apps and games on Google Pla...",
   "siteName": null,

--- a/test-pages/readability/mercurial/expected.html
+++ b/test-pages/readability/mercurial/expected.html
@@ -1,5 +1,6 @@
 <div id="readability-page-1" class="page">
     <div id="evolve-shared-mutable-history">
+        <h2><a href="#id4">Evolve: Shared Mutable History</a><a href="#evolve-shared-mutable-history" title="Permalink to this headline">¶</a></h2>
         <div id="contents">
             <p> Contents </p>
             <ul>

--- a/test-pages/readability/simplyfound-1/expected-metadata.json
+++ b/test-pages/readability/simplyfound-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Raspberry Pi 3 - The credit card sized PC that cost only $35 - All-time bestselling computer in UK",
-  "byline": null,
+  "byline": "Joe Wee Monday, February 29, 2016 @ 11:10 PM UTC",
   "dir": null,
   "lang": "en",
   "excerpt": "The Raspberry Pi Foundation started by a handful of volunteers in 2012 when they released the original Raspberry Pi 256MB Model B without knowing what to expect. In a short four-year period they have grown to over sixty full-time employees and ha...",

--- a/test-pages/readability/telegraph/expected-metadata.json
+++ b/test-pages/readability/telegraph/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Zimbabwe coup: Robert Mugabe and wife Grace 'insisting he finishes his term', as priest steps in to mediate",
-  "byline": null,
+  "byline": "Our Foreign Staff",
   "dir": null,
   "lang": "en-GB",
   "excerpt": "Zimbabwe President Robert Mugabe, his wife Grace and two key figures from her G40 political faction are under house arrest at Mugabe's \"Blue House\" compound in Harare and are insisting the 93 year-old finishes his presidential term, a source said.",

--- a/test-pages/readability/webmd-1/expected-metadata.json
+++ b/test-pages/readability/webmd-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Babies Who Eat Peanuts Early May Avoid Allergy",
-  "byline": "By Brenda  Goodman, MA\n                                                WebMD Health News",
+  "byline": "By Brenda Goodman, MA WebMD Health News",
   "dir": null,
   "lang": "en",
   "excerpt": "Life-threatening peanut allergies have mysteriously been on the rise in the past decade, with little hope for a cure. But a groundbreaking new study may offer a way to stem that rise, while another may offer some hope for those who are already allergic.",

--- a/test-pages/readability/webmd-2/expected-metadata.json
+++ b/test-pages/readability/webmd-2/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Superbugs: What They Are and How You Get Them",
-  "byline": "By Kelli  Miller\n                                                    WebMD Health News",
+  "byline": "By Kelli Miller WebMD Health News",
   "dir": null,
   "lang": "en",
   "excerpt": "Drug-resistant bacteria, dubbed",

--- a/test-pages/readability/wordpress/expected-metadata.json
+++ b/test-pages/readability/wordpress/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Stack Overflow Jobs Data Shows ReactJS Skills in High Demand, WordPress Market Oversaturated with Developers",
-  "byline": null,
+  "byline": "Sarah Gooding",
   "dir": "ltr",
   "lang": "en-US",
   "excerpt": "Stack Overflow published its analysis of 2017 hiring trends based on the targeting options employers selected when posting to Stack Overflow Jobs. The report, which compares data from 200 companies…",

--- a/test-pages/readability/yahoo-3/expected-metadata.json
+++ b/test-pages/readability/yahoo-3/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Veteran Wraps Baby in American Flag, Photo Sparks Controversy",
-  "byline": "By GILLIAN MOHNEY\n                                March 11, 2015 3:46 PM",
+  "byline": "By GILLIAN MOHNEY March 11, 2015 3:46 PM",
   "dir": "ltr",
   "lang": "en-US",
   "excerpt": "A photographer and Navy veteran is fighting back after a photo she posted to Facebook started an online backlash. Vanessa Hicks said she had no idea her photo would be considered controversial. The photo, from a military family’s newborn photo shoot, showed a newborn infant wrapped in an American flag held by his father, who was in his military uniform. Hicks, a Navy veteran herself and the wife of an active-duty Navy member, said her intention was to honor the flag as well as her clients, who wanted to incorporate their military service in the photo shoot.",

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -21,11 +21,12 @@ fn test_skip_body_ancestor() {
     let res = ra.parse().unwrap();
     let expected: String = r#"<div id="readability-page-1" class="page">
         <p><a href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
-        </div>"#.split_whitespace().collect();
+        </div>"#
+        .split_whitespace()
+        .collect();
     let got: String = res.content.split_whitespace().collect();
     assert_eq!(got, expected);
 }
-
 
 #[test]
 fn test_skip_body_ancestor_fragment() {
@@ -39,8 +40,9 @@ fn test_skip_body_ancestor_fragment() {
     let res = ra.parse().unwrap();
     let expected: String = r#"<div id="readability-page-1" class="page"><div>
         <p><a href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
-        </div></div>"#.split_whitespace().collect();
+        </div></div>"#
+        .split_whitespace()
+        .collect();
     let got: String = res.content.split_whitespace().collect();
     assert_eq!(got, expected);
 }
-


### PR DESCRIPTION
- **Breaking** Revised document filtering. Since most of the filtering is now separated from extracting elements for scoring, there is a higher chance of assigning `Metadata.title` if it was empty before grabbing the article. The same applies to `Metadata.byline`, which previously could incorrectly assign a commentator as the article's author or leave it missing altogether. In the `mozilla/readability` test pages, I've encountered cases where this happened because `Readability` failed to extract readable content on the first iteration.
- If Metadata.byline was assigned while grabbing the article, it will be normalized (no new lines or trailing spaces).