### PR TITLE
src/config.rs: `Config` implements `#[serde(default)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `Config` now implements `#[serde(default)]`. This change makes it more convenient to work with serde by removing the need to explicitly set every value in `Config`.
+
 ## [0.5.0] - 2025-02-06
 
 ### Added

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub enum TextMode {
 /// Configuration options for [`crate::Readability`]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct Config {
     /// Set to `true` to keep all classes in the document
     pub keep_classes: bool,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit
- **Bug Fixes**
  - Improved configuration usability by enabling automatic default value handling, so users no longer need to supply every setting manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->