### PR TITLE
add markdown support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `Readability::parse` can now output text as `Markdown` in `Article::text_content` when `Config::text_mode` is set to `TextMode::Markdown`.
+
 ### Changed
-- Update `dom_query`'s version to `0.15.0`.
+- Update `dom_query`'s version to `0.15.1`.
 - Minor code changes.
 
 ## [0.6.1] - 2025-02-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcd03b6d3a798939555fd74fe02ecb158326bbab56adce6cc711d659599558c"
+checksum = "cff093d41a137417266edb337adcb64e175f38db6b906e5953b3a20cb6f705d4"
 dependencies = [
  "bit-set",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 exclude = [".*", "test-pages", "benches"]
 
 [dependencies]
-dom_query = {version = "0.15.0", features = ["mini_selector", "markdown"]}
+dom_query = {version = "0.15.1", features = ["mini_selector", "markdown"]}
 tendril = {version = "0.4.3"}
 once_cell = { version = "1" }
 serde = {version = "1.0", features = ["derive"], optional = true}

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ To retrieve formatted text content, set text_mode: `TextMode::Formatted` in the 
 This formatting does not preserve table structures, meaning table data may be output as plain text without column alignment.
 While this formatting is not as structured as Markdown, it provides a cleaner output compared to raw text.
 
-`TextMode::Markdown` enables markdown formatting.
+`TextMode::Markdown` enables Markdown formatting.
 
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -242,18 +242,17 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 
 <details>
-    <summary><b>Formatted text content</b></summary>
+    <summary><b>Formatted text content and Markdown</b></summary>
 
 By default, the text content is output as-is, without formatting, 
 preserving whitespace from the original HTML document. 
 Depending on the document's initial markup, this can be quite verbose and inconvenient.
 
-In version 0.5.0, it will be possible to retrieve formatted text content. 
-To enable this, set `text_mode: TextMode::Formatted` in the config.
-This formatting is simple; for example, it does not account for table formatting.
-It is certainly nowhere near markdown-level, but the result is noticeably 
-cleaner than without formatting.
+To retrieve formatted text content, set text_mode: `TextMode::Formatted` in the config.
+This formatting does not preserve table structures, meaning table data may be output as plain text without column alignment.
+While this formatting is not as structured as Markdown, it provides a cleaner output compared to raw text.
 
+`TextMode::Markdown` enables markdown formatting.
 
 
 ```rust
@@ -267,6 +266,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cfg = Config {
         // Enable formatted text output
         text_mode: TextMode::Formatted,
+        // Enable Markdown output (for more structured text)
+        //text_mode: TextMode::Markdown,
         ..Default::default()
     };
 

--- a/dom-smoothie-js/README.md
+++ b/dom-smoothie-js/README.md
@@ -15,7 +15,7 @@
 | readable_min_score         | `number` (float)          | `20.0`                             | Minimum score required for readability check |
 | readable_min_content_length| `number`                  | `140`                              | Minimum content length for readability check |
 | candidate_select_mode      | `'Readability' \| 'DomSmoothie'` | `'Readability'`                 | Candidate selection mode |
-| text_mode                  | `'Raw' \| 'Formatted' \| 'Markdown'`    | `'Raw'`                            | Text output mode, either raw or formatted |
+| text_mode                  | `'Raw' \| 'Formatted' \| 'Markdown'`    | `'Raw'`                            | Text output mode, either raw, formatted or Markdown |
 
 ### Example Object with Default Parameters
 

--- a/dom-smoothie-js/README.md
+++ b/dom-smoothie-js/README.md
@@ -224,7 +224,7 @@ To retrieve formatted text content, set text_mode: `TextMode::Formatted` in the 
 This formatting does not preserve table structures, meaning table data may be output as plain text without column alignment.
 While this formatting is not as structured as Markdown, it provides a cleaner output compared to raw text.
 
-`TextMode::Markdown` enables markdown formatting.
+`TextMode::Markdown` enables Markdown formatting.
 
 ```javascript
 import { Readability } from "dom-smoothie-js";

--- a/dom-smoothie-js/README.md
+++ b/dom-smoothie-js/README.md
@@ -15,7 +15,7 @@
 | readable_min_score         | `number` (float)          | `20.0`                             | Minimum score required for readability check |
 | readable_min_content_length| `number`                  | `140`                              | Minimum content length for readability check |
 | candidate_select_mode      | `'Readability' \| 'DomSmoothie'` | `'Readability'`                 | Candidate selection mode |
-| text_mode                  | `'Raw' \| 'Formatted'`    | `'Raw'`                            | Text output mode, either raw or formatted |
+| text_mode                  | `'Raw' \| 'Formatted' \| 'Markdown'`    | `'Raw'`                            | Text output mode, either raw or formatted |
 
 ### Example Object with Default Parameters
 
@@ -214,17 +214,17 @@ main();
 
 
 <details>
-    <summary><b>Formatted text content</b></summary>
+    <summary><b>Formatted text content and Markdown</b></summary>
 
 By default, the text content is output as-is, without formatting, 
 preserving whitespace from the original HTML document. 
 Depending on the document's initial markup, this can be quite verbose and inconvenient.
 
-But it is also possible to retrieve formatted text content. 
-To enable this, set `text_mode: TextMode::Formatted` in the config.
-This formatting is simple; for example, it does not account for table formatting.
-It is certainly nowhere near markdown-level, but the result is noticeably 
-cleaner than without formatting.
+To retrieve formatted text content, set text_mode: `TextMode::Formatted` in the config.
+This formatting does not preserve table structures, meaning table data may be output as plain text without column alignment.
+While this formatting is not as structured as Markdown, it provides a cleaner output compared to raw text.
+
+`TextMode::Markdown` enables markdown formatting.
 
 ```javascript
 import { Readability } from "dom-smoothie-js";
@@ -235,6 +235,7 @@ function main() {
 
   const cfg = {
     text_mode: "Formatted",
+    //text_mode: "Markdown",
   };
 
   const readability = new Readability(content, null, cfg);

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub enum TextMode {
     #[default]
     Raw,
     Formatted,
+    Markdown,
 }
 
 /// Configuration options for [`crate::Readability`]
@@ -46,7 +47,7 @@ pub struct Config {
     /// based on [Readability.js](https://github.com/mozilla/readability)
     /// or uses the crate's exclusive implementation.
     pub candidate_select_mode: CandidateSelectMode,
-    /// Allows to set the text mode, whether it should be raw (as-is) or formatted
+    /// Allows to set the text mode, whether it should be raw (as-is), formatted or markdown
     pub text_mode: TextMode,
 }
 

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -512,6 +512,7 @@ impl Readability {
         let text_content = match self.config.text_mode {
             TextMode::Raw => root_node.text(),
             TextMode::Formatted => root_node.formatted_text(),
+            TextMode::Markdown => root_node.md(None),
         };
         let text_length = text_content.chars().count();
 

--- a/test-pages/alt/arstechnica/expected.md
+++ b/test-pages/alt/arstechnica/expected.md
@@ -1,0 +1,29 @@
+Ownership, now that's a tricky word
+
+Just because it's a good rig doesn't mean you can use it on Zoom\.
+
+The Canon PowerShot G5 X II, which is either less valuable than a $50 USB webcam or far better, depending on your Canon subscription software\. Credit: Canon
+
+Photography enthusiasts pay a lot for their very powerful cameras\. How much more should they pay to put them to much, much easier work as a webcam? However many hundreds of dollars you paid, Canon thinks you should pay $5 per month—or, heck, just $50 per year—to do that\.
+
+Roman Zipp detailed his journey from incredulousness to grim resignation in [a blog post](https://romanzipp.com/blog/no-you-cant-use-your-6299-canon-camera-as-a-webcam)\. He bought his [Canon PowerShot G5 X Mark II](https://www.dpreview.com/products/canon/compacts/canon_g5xii) for something like $900 last year\. The compact model gave him the right match of focal length and sensor size for concert pics\. What it did not give him was the ability to change anything at all about his webcam feed using Canon's software\. \(The "$6,299 camera" referenced in Zipp's blog post title is his indication that all models of Canon's cameras face this conundrum, regardless of price point\.\)
+
+Ah, but that's because Zipp did not pay\. If you head to Canon's site, provide a name and email, and manage to grab the EOS Webcam utility when Canon's servers are not failing, you can connect one camera, with one default scene, at 720p, 30 frames per second and adjust everything on the camera itself if you need to\. Should you pay $5 per month, or $50 per year, you can unlock [EOS Webcam Utility Pro](file:///C:/Users/kspur/Downloads/How%20to%20Subscribe.pdf) \(PDF link\), which provides full 60 fps video and most of the features you'd expect out of a webcam that cost hundreds fewer dollars\.
+
+Comparison of webcam software features available to Canon's "PRO" and "Free" users\.
+
+Credit: Roman Zipp/Canon
+
+Comparison of webcam software features available to Canon's "PRO" and "Free" users\. Credit: Roman Zipp/Canon
+
+"Software development isn’t free, and I’m happy to pay for software I use regularly," Zipp writes\. "However, Canon is a hardware company, not a software company, and they should—due to the lack of standards—provide software that allows you to use their cameras as intended\. Aside from development costs, there’s no justification for a subscription model, particularly from a company earning nearly [$3 billion in profit](https://global.canon/en/ir/finance/highlight.html)\."
+
+Zipp's pointed complaint made the front page of Hacker News, where commenters immediately got sidetracked into a discussion of UK tariff laws on video equipment, sneakers, cookies, and ethanol\. But further in, recommendations appear for the open source [Magic Lantern](https://www.magiclantern.fm/) camera add-on software, or possibly [CHDK](https://chdk.fandom.com/wiki/CHDK) \(Canon Hack Development Kit\) firmware\. Whether or not Zipp can better use his camera as a webcam is somewhat beside the point, or at least the point he's making\.
+
+Many higher-end \(or at least better-than-smartphone\) cameras output video in formats that computers and web conferencing software cannot natively accept\. HDMI output is an option, but using that typically requires a capture device and specialty software to mix and use it and that the camera provide "clean" HDMI out, with no overlays\. The G5 X Mark II does seem to offer that and has a USB-C port\. It also seems to work fine once the software is paid for\. It's an open question whether Canon should provide this as part of the cost of the camera, one for which Zipp and many commenters have an answer\.
+
+Ars has reached out to Canon for comment and will update this post if the company responds\.
+
+Kevin is a senior technology reporter at Ars Technica, covering open-source software, PC gaming, home automation, repairability, e-bikes, and tech history\. He has previously worked at Lifehacker, Wirecutter, iFixit, and Carbon Switch\.
+
+[285 Comments ](https://arstechnica.com/gadgets/2025/01/canon-charges-50-per-year-to-use-a-900-camera-as-a-functional-webcam/#comments "285 comments")

--- a/test-pages/alt/hacker-news/expected.md
+++ b/test-pages/alt/hacker-news/expected.md
@@ -1,0 +1,91 @@
+1\.[Steam Brick: No screen, no controller, just a power button and a USB port](https://crastinator-pro.github.io/steam-brick/) \([crastinator-pro\.github\.io](from?site=crastinator-pro.github.io)\)
+568 points by [sbarre](user?id=sbarre) [14 hours ago](item?id=42825441) \| [hide](hide?id=42825441&goto=news) \| [167 comments](item?id=42825441)
+
+2\.[DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via RL](https://arxiv.org/abs/2501.12948) \([arxiv\.org](from?site=arxiv.org)\)
+823 points by [gradus\_ad](user?id=gradus_ad) [17 hours ago](item?id=42823568) \| [hide](hide?id=42823568&goto=news) \| [694 comments](item?id=42823568)
+
+3\.[YC Graveyard: 821 inactive Y Combinator startups](https://ycgraveyard.iamwillwang.com/) \([iamwillwang\.com](from?site=iamwillwang.com)\)
+139 points by [memalign](user?id=memalign) [5 hours ago](item?id=42828198) \| [hide](hide?id=42828198&goto=news) \| [76 comments](item?id=42828198)
+
+4\.[When AI Promises Speed but Delivers Debugging Hell](https://nsavage.substack.com/p/when-ai-promises-speed-but-delivers) \([nsavage\.substack\.com](from?site=nsavage.substack.com)\)
+5 points by [nsavage](user?id=nsavage) [50 minutes ago](item?id=42829466) \| [hide](hide?id=42829466&goto=news) \| [discuss](item?id=42829466)
+
+5\.[OpenRA – Classic strategy games rebuilt for the modern era](https://www.openra.net/) \([openra\.net](from?site=openra.net)\)
+433 points by [tosh](user?id=tosh) [17 hours ago](item?id=42823667) \| [hide](hide?id=42823667&goto=news) \| [72 comments](item?id=42823667)
+
+6\.[The South Vietnamese pilot who landed a Cessna on a carrier to save his family \(2019\)](https://www.historynet.com/maj-buang-lys-daring-feat-to-save-his-family/) \([historynet\.com](from?site=historynet.com)\)
+227 points by [stmw](user?id=stmw) [11 hours ago](item?id=42826536) \| [hide](hide?id=42826536&goto=news) \| [89 comments](item?id=42826536)
+
+7\.[Emerging Reasoning with Reinforcement Learning](https://hkust-nlp.notion.site/simplerl-reason) \([hkust-nlp\.notion\.site](from?site=hkust-nlp.notion.site)\)
+164 points by [pella](user?id=pella) [9 hours ago](item?id=42827399) \| [hide](hide?id=42827399&goto=news) \| [130 comments](item?id=42827399)
+
+8\.[The Simplicity of Prolog](https://bitsandtheorems.com/the-simplicity-of-prolog/) \([bitsandtheorems\.com](from?site=bitsandtheorems.com)\)
+73 points by [thunderbong](user?id=thunderbong) [9 hours ago](item?id=42827335) \| [hide](hide?id=42827335&goto=news) \| [19 comments](item?id=42827335)
+
+9\.[An invalid 68030 instruction accidentally allowed the Mac Classic II to boot](https://www.downtowndougbrown.com/2025/01/the-invalid-68030-instruction-that-accidentally-allowed-the-mac-classic-ii-to-successfully-boot-up/) \([downtowndougbrown\.com](from?site=downtowndougbrown.com)\)
+232 points by [todsacerdoti](user?id=todsacerdoti) [15 hours ago](item?id=42824562) \| [hide](hide?id=42824562&goto=news) \| [42 comments](item?id=42824562)
+
+10\.[Every HTML Element](https://iamwillwang.com/dollar/every-html-element/) \([iamwillwang\.com](from?site=iamwillwang.com)\)
+326 points by [wxw](user?id=wxw) [17 hours ago](item?id=42823722) \| [hide](hide?id=42823722&goto=news) \| [100 comments](item?id=42823722)
+
+11\.[I ask this chess puzzle to every new LLM](https://gist.github.com/abhishek-anand/a65ff0e44d158ae306dcce9151b1331c) \([gist\.github\.com](from?site=gist.github.com)\)
+17 points by [thepoet](user?id=thepoet) [4 hours ago](item?id=42795488) \| [hide](hide?id=42795488&goto=news) \| [19 comments](item?id=42795488)
+
+12\.[SQLook – A free online SQLite database manager with a Windows 2000 interface](https://sqlook.com) \([sqlook\.com](from?site=sqlook.com)\)
+124 points by [gringow](user?id=gringow) [12 hours ago](item?id=42826171) \| [hide](hide?id=42826171&goto=news) \| [36 comments](item?id=42826171)
+
+13\.[Apache Iceberg](https://iceberg.apache.org/) \([apache\.org](from?site=apache.org)\)
+105 points by [jacobmarble](user?id=jacobmarble) [12 hours ago](item?id=42799388) \| [hide](hide?id=42799388&goto=news) \| [34 comments](item?id=42799388)
+
+14\.[Explainer: What's R1 and Everything Else?](https://timkellogg.me/blog/2025/01/25/r1) \([timkellogg\.me](from?site=timkellogg.me)\)
+62 points by [Philpax](user?id=Philpax) [8 hours ago](item?id=42827601) \| [hide](hide?id=42827601&goto=news) \| [9 comments](item?id=42827601)
+
+15\.[The Graphics Codex](https://graphicscodex.com/) \([graphicscodex\.com](from?site=graphicscodex.com)\)
+25 points by [board](user?id=board) [6 hours ago](item?id=42827976) \| [hide](hide?id=42827976&goto=news) \| [3 comments](item?id=42827976)
+
+16\.[The Hunt for Error -22](https://tweedegolf.nl/en/blog/145/the-hunt-for-error--22) \([tweedegolf\.nl](from?site=tweedegolf.nl)\)
+10 points by [mpalme](user?id=mpalme) [3 hours ago](item?id=42791874) \| [hide](hide?id=42791874&goto=news) \| [4 comments](item?id=42791874)
+
+17\. ![](s.gif) [SigNoz \(YC W21\) Is hiring back end engineers to build open-source Datadog](https://www.linkedin.com/posts/pranay01_inviting-backend-engineers-interested-activity-7275015683980075008-CzV9) \([linkedin\.com](from?site=linkedin.com)\)
+[5 hours ago](item?id=42828294) \| [hide](hide?id=42828294&goto=news)
+
+18\.[Bacteria in Polymers Form Cables That Grow into Living Gels](https://www.caltech.edu/about/news/bacteria-in-polymers-form-cables-that-grow-into-living-gels) \([caltech\.edu](from?site=caltech.edu)\)
+38 points by [gmays](user?id=gmays) [8 hours ago](item?id=42805777) \| [hide](hide?id=42805777&goto=news) \| [2 comments](item?id=42805777)
+
+19\.[Searching for DeepSeek's glitch tokens](https://outsidetext.substack.com/p/anomalous-tokens-in-deepseek-v3-and) \([outsidetext\.substack\.com](from?site=outsidetext.substack.com)\)
+148 points by [arithmoquine](user?id=arithmoquine) [16 hours ago](item?id=42824473) \| [hide](hide?id=42824473&goto=news) \| [39 comments](item?id=42824473)
+
+20\.[An experiment of adding recommendation engine to your app using pgvector search](https://silk.us/blog/vector-search-ai-integration/) \([silk\.us](from?site=silk.us)\)
+44 points by [tanelpoder](user?id=tanelpoder) [11 hours ago](item?id=42804406) \| [hide](hide?id=42804406&goto=news) \| [3 comments](item?id=42804406)
+
+21\.[Wikenigma – an Encyclopedia of Unknowns](https://wikenigma.org.uk/start) \([wikenigma\.org\.uk](from?site=wikenigma.org.uk)\)
+134 points by [jgamman](user?id=jgamman) [15 hours ago](item?id=42824617) \| [hide](hide?id=42824617&goto=news) \| [35 comments](item?id=42824617)
+
+22\.[You probably don't need query builders](https://mattrighetti.com/2025/01/20/you-dont-need-sql-builders) \([mattrighetti\.com](from?site=mattrighetti.com)\)
+111 points by [mattrighetti](user?id=mattrighetti) [17 hours ago](item?id=42778151) \| [hide](hide?id=42778151&goto=news) \| [102 comments](item?id=42778151)
+
+23\.[Open Heart Protocol](https://openheart.fyi/) \([openheart\.fyi](from?site=openheart.fyi)\)
+199 points by [thunderbong](user?id=thunderbong) [21 hours ago](item?id=42791378) \| [hide](hide?id=42791378&goto=news) \| [84 comments](item?id=42791378)
+
+24\.[Using AI to develop a fuller model of the human brain](https://magazine.ucsf.edu/building-a-silicon-brain) \([ucsf\.edu](from?site=ucsf.edu)\)
+72 points by [geox](user?id=geox) [15 hours ago](item?id=42824625) \| [hide](hide?id=42824625&goto=news) \| [27 comments](item?id=42824625)
+
+25\.[Mastering Atari Games with Natural Intelligence](https://www.verses.ai/blog/mastering-atari-games-with-natural-intelligence) \([verses\.ai](from?site=verses.ai)\)
+19 points by [alex\_c](user?id=alex_c) [7 hours ago](item?id=42806998) \| [hide](hide?id=42806998&goto=news) \| [7 comments](item?id=42806998)
+
+26\.[How far can you get in 40 minutes from each subway station in NYC?](https://subwaysheds.com/#11.27/40.7427/-73.9869) \([subwaysheds\.com](from?site=subwaysheds.com)\)
+277 points by [jxmorris12](user?id=jxmorris12) [1 day ago](item?id=42810293) \| [hide](hide?id=42810293&goto=news) \| [168 comments](item?id=42810293)
+
+27\.[Ask HN: How to automate collecting HAR file while user is browsing](item?id=42817554)
+11 points by [royalghost](user?id=royalghost) [4 hours ago](item?id=42817554) \| [hide](hide?id=42817554&goto=news) \| [9 comments](item?id=42817554)
+
+28\.[A FPGA friendly 32 bit RISC-V CPU implementation](https://github.com/SpinalHDL/VexRiscv) \([github\.com/spinalhdl](from?site=github.com/spinalhdl)\)
+105 points by [\_benj](user?id=_benj) [20 hours ago](item?id=42793580) \| [hide](hide?id=42793580&goto=news) \| [48 comments](item?id=42793580)
+
+29\.[Using Linear Programming to find optimal builds in League of Legend](https://versary.town/blog/using-linear-programming-to-find-optimal-builds-in-league-of-legends/) \([versary\.town](from?site=versary.town)\)
+20 points by [birdculture](user?id=birdculture) [6 hours ago](item?id=42796292) \| [hide](hide?id=42796292&goto=news) \| [7 comments](item?id=42796292)
+
+30\.[Immutability Changes Everything \(2016\) \[pdf\]](https://www.cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf) \([cidrdb\.org](from?site=cidrdb.org)\)
+88 points by [fire\_lake](user?id=fire_lake) [15 hours ago](item?id=42824983) \| [hide](hide?id=42824983&goto=news) \| [29 comments](item?id=42824983)
+
+[More](?p=2)

--- a/test-pages/alt/mozilla_readability/expected.md
+++ b/test-pages/alt/mozilla_readability/expected.md
@@ -1,0 +1,115 @@
+A standalone version of the readability library used for [Firefox Reader View](https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages)\.
+
+Readability is available on npm:
+
+
+```
+npm install @mozilla/readability
+```
+
+
+You can then `require()` it, or for web-based projects, load the `Readability.js` script from your webpage\.
+
+To parse a document, you must create a new `Readability` object from a DOM document object, and then call the [parse\(\)](#parse) method\. Here's an example:
+
+
+```
+var article = new Readability(document).parse();
+```
+
+
+If you use Readability in a web browser, you will likely be able to use a `document` reference from elsewhere \(e\.g\. fetched via XMLHttpRequest, in a same-origin `<iframe>` you have access to, etc\.\)\. In Node\.js, you can [use an external DOM library](#nodejs-usage)\.
+
+The `options` object accepts a number of properties, all optional:
+
+- `debug` \(boolean, default `false`\): whether to enable logging\.
+- `maxElemsToParse` \(number, default `0` i\.e\. no limit\): the maximum number of elements to parse\.
+- `nbTopCandidates` \(number, default `5`\): the number of top candidates to consider when analysing how tight the competition is among candidates\.
+- `charThreshold` \(number, default `500`\): the number of characters an article must have in order to return a result\.
+- `classesToPreserve` \(array\): a set of classes to preserve on HTML elements when the `keepClasses` options is set to `false`\.
+- `keepClasses` \(boolean, default `false`\): whether to preserve all classes on HTML elements\. When set to `false` only classes specified in the `classesToPreserve` array are kept\.
+- `disableJSONLD` \(boolean, default `false`\): when extracting page metadata, Readability gives precedence to Schema\.org fields specified in the JSON-LD format\. Set this option to `true` to skip JSON-LD parsing\.
+- `serializer` \(function, default `el => el.innerHTML`\) controls how the `content` property returned by the `parse()` method is produced from the root DOM element\. It may be useful to specify the `serializer` as the identity function \(`el => el`\) to obtain a DOM element instead of a string for `content` if you plan to process it further\.
+- `allowedVideoRegex` \(RegExp, default `undefined` \): a regular expression that matches video URLs that should be allowed to be included in the article content\. If `undefined`, the [default regex](https://github.com/mozilla/readability/blob/8e8ec27cd2013940bc6f3cc609de10e35a1d9d86/Readability.js#L133) is applied\.
+- `linkDensityModifier` \(number, default `0`\): a number that is added to the base link density threshold during the shadiness checks\. This can be used to penalize nodes with a high link density or vice versa\.
+Returns an object containing the following properties:
+
+- `title`: article title;
+- `content`: HTML string of processed article content;
+- `textContent`: text content of the article, with all the HTML tags removed;
+- `length`: length of an article, in characters;
+- `excerpt`: article description, or short excerpt from the content;
+- `byline`: author metadata;
+- `dir`: content direction;
+- `siteName`: name of the site;
+- `lang`: content language;
+- `publishedTime`: published time;
+The `parse()` method works by modifying the DOM\. This removes some elements in the web page, which may be undesirable\. You can avoid this by passing the clone of the `document` object to the `Readability` constructor:
+
+
+```
+var documentClone = document.cloneNode(true);
+var article = new Readability(documentClone).parse();
+```
+
+
+A quick-and-dirty way of figuring out if it's plausible that the contents of a given document are suitable for processing with Readability\. It is likely to produce both false positives and false negatives\. The reason it exists is to avoid bogging down a time-sensitive process \(like loading and showing the user a webpage\) with the complex logic in the core of Readability\. Improvements to its logic \(while not deteriorating its performance\) are very welcome\.
+
+The `options` object accepts a number of properties, all optional:
+
+- `minContentLength` \(number, default `140`\): the minimum node content length used to decide if the document is readerable;
+- `minScore` \(number, default `20`\): the minimum cumulated 'score' used to determine if the document is readerable;
+- `visibilityChecker` \(function, default `isNodeVisible`\): the function used to determine if a node is visible;
+The function returns a boolean corresponding to whether or not we suspect `Readability.parse()` will succeed at returning an article object\. Here's an example:
+
+
+```
+/*
+    Only instantiate Readability  if we suspect
+    the `parse()` method will produce a meaningful result.
+*/
+if (isProbablyReaderable(document)) {
+    let article = new Readability(document).parse();
+}
+```
+
+
+Since Node\.js does not come with its own DOM implementation, we rely on external libraries like [jsdom](https://github.com/jsdom/jsdom)\. Here's an example using `jsdom` to obtain a DOM document object:
+
+
+```
+var { Readability } = require('@mozilla/readability');
+var { JSDOM } = require('jsdom');
+var doc = new JSDOM("<body>Look at this cat: <img src='./cat.jpg'></body>", {
+  url: "https://www.example.com/the-page-i-got-the-source-from"
+});
+let reader = new Readability(doc.window.document);
+let article = reader.parse();
+```
+
+
+Remember to pass the page's URI as the `url` option in the `JSDOM` constructor \(as shown in the example above\), so that Readability can convert relative URLs for images, hyperlinks, etc\. to their absolute counterparts\.
+
+`jsdom` has the ability to run the scripts included in the HTML and fetch remote resources\. For security reasons these are [disabled by default](https://github.com/jsdom/jsdom#executing-scripts), and we **strongly** recommend you keep them that way\.
+
+If you're going to use Readability with untrusted input \(whether in HTML or DOM form\), we **strongly** recommend you use a sanitizer library like [DOMPurify](https://github.com/cure53/DOMPurify) to avoid script injection when you use the output of Readability\. We would also recommend using [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to add further defense-in-depth restrictions to what you allow the resulting content to do\. The Firefox integration of reader mode uses both of these techniques itself\. Sanitizing unsafe content out of the input is explicitly not something we aim to do as part of Readability itself - there are other good sanitizer libraries out there, use them\!
+
+Please see our [Contributing](/mozilla/readability/blob/main/CONTRIBUTING.md) document\.
+
+
+```
+Copyright (c) 2010 Arc90 Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```

--- a/test-pages/alt/rust-blog/expected.md
+++ b/test-pages/alt/rust-blog/expected.md
@@ -1,0 +1,125 @@
+The Rust team is happy to announce a new version of Rust, 1\.84\.0\. Rust is a programming language empowering everyone to build reliable and efficient software\.
+
+If you have a previous version of Rust installed via `rustup`, you can get 1\.84\.0 with:
+
+
+```
+$ rustup update stable
+
+```
+If you don't have it already, you can [get rustup](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1\.84\.0](https://doc.rust-lang.org/stable/releases.html#version-1840-2025-01-09)\.
+
+If you'd like to help us out by testing future releases, you might consider updating locally to use the beta channel \(`rustup default beta`\) or the nightly channel \(`rustup default nightly`\)\. Please [report](https://github.com/rust-lang/rust/issues/new/choose) any bugs you might come across\!
+
+## What's in 1\.84\.0 stable
+
+### Cargo considers Rust versions for dependency version selection
+
+1\.84\.0 stabilizes the minimum supported Rust version \(MSRV\) aware resolver, which prefers dependency versions compatible with the project's declared [MSRV](https://doc.rust-lang.org/cargo/reference/rust-version.html)\. With MSRV-aware version selection, the toil is reduced for maintainers to support older toolchains by not needing to manually select older versions for each dependency\.
+
+You can opt-in to the MSRV-aware resolver via [\.cargo/config\.toml](https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions):
+
+
+```
+[resolver]
+incompatible-rust-versions = "fallback"
+
+```
+Then when adding a dependency:
+
+
+```
+$ cargo add clap
+    Updating crates.io index
+warning: ignoring clap@4.5.23 (which requires rustc 1.74) to maintain demo's rust-version of 1.60
+      Adding clap v4.0.32 to dependencies
+    Updating crates.io index
+     Locking 33 packages to latest Rust 1.60 compatible versions
+      Adding clap v4.0.32 (available: v4.5.23, requires Rust 1.74)
+
+```
+When [verifying the latest dependencies in CI](https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-latest-dependencies), you can override this:
+
+
+```
+$ CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=allow cargo update
+    Updating crates.io index
+     Locking 12 packages to latest compatible versions
+    Updating clap v4.0.32 -> v4.5.23
+
+```
+You can also opt-in by setting [package\.resolver = "3"](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) in the Cargo\.toml manifest file though that will require raising your MSRV to 1\.84\. The new resolver will be enabled by default for projects using the 2024 edition \(which will stabilize in 1\.85\)\.
+
+This gives library authors more flexibility when deciding their policy on adopting new Rust toolchain features\. Previously, a library adopting features from a new Rust toolchain would force downstream users of that library who have an older Rust version to either upgrade their toolchain or manually select an old version of the library compatible with their toolchain \(and avoid running `cargo update`\)\. Now, those users will be able to automatically use older library versions compatible with their older toolchain\.
+
+See the [documentation](https://doc.rust-lang.org/cargo/reference/rust-version.html#setting-and-updating-rust-version) for more considerations when deciding on an MSRV policy\.
+
+### Migration to the new trait solver begins
+
+The Rust compiler is in the process of moving to a new implementation for the trait solver\. The next-generation trait solver is a reimplementation of a core component of Rust's type system\. It is not only responsible for checking whether trait-bounds - e\.g\. `Vec<T>: Clone` - hold, but is also used by many other parts of the type system, such as normalization - figuring out the underlying type of `<Vec<T> as IntoIterator>::Item` - and equating types \(checking whether `T` and `U` are the same\)\.
+
+In 1\.84, the new solver is used for checking coherence of trait impls\. At a high level, coherence is responsible for ensuring that there is at most one implementation of a trait for a given type while considering not yet written or visible code from other crates\.
+
+This stabilization fixes a few mostly theoretical correctness issues of the old implementation, resulting in potential "conflicting implementations of trait \.\.\." errors that were not previously reported\. We expect the affected patterns to be very rare based on evaluation of available code through [Crater](https://github.com/rust-lang/crater/)\. The stabilization also improves our ability to prove that impls do *not* overlap, allowing more code to be written in some cases\.
+
+For more details, see a [previous blog post](https://blog.rust-lang.org/inside-rust/2024/12/04/trait-system-refactor-initiative.html) and the [stabilization report](https://github.com/rust-lang/rust/pull/130654)\.
+
+### Strict provenance APIs
+
+In Rust, [pointers are not simply an "integer" or "address"](https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html)\. For instance, a "use after free" is undefined behavior even if you "get lucky" and the freed memory gets reallocated before your read/write\. As another example, writing through a pointer derived from an `&i32` reference is undefined behavior, even if writing to the same address via a different pointer is legal\. The underlying pattern here is that *the way a pointer is computed matters*, not just the address that results from this computation\. For this reason, we say that pointers have **provenance**: to fully characterize pointer-related undefined behavior in Rust, we have to know not only the address the pointer points to, but also track which other pointer\(s\) it is "derived from"\.
+
+Most of the time, programmers do not need to worry much about provenance, and it is very clear how a pointer got derived\. However, when casting pointers to integers and back, the provenance of the resulting pointer is underspecified\. With this release, Rust is adding a set of APIs that can in many cases replace the use of integer-pointer-casts, and therefore avoid the ambiguities inherent to such casts\. In particular, the pattern of using the lowest bits of an aligned pointer to store extra information can now be implemented without ever casting a pointer to an integer or back\. This makes the code easier to reason about, easier to analyze for the compiler, and also benefits tools like [Miri](https://github.com/rust-lang/miri) and architectures like [CHERI](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/) that aim to detect and diagnose pointer misuse\.
+
+For more details, see the standard library [documentation on provenance](https://doc.rust-lang.org/std/ptr/index.html#provenance)\.
+
+### Stabilized APIs
+
+- [Ipv6Addr::is\_unique\_local](https://doc.rust-lang.org/stable/core/net/struct.Ipv6Addr.html#method.is_unique_local)
+- [Ipv6Addr::is\_unicast\_link\_local](https://doc.rust-lang.org/stable/core/net/struct.Ipv6Addr.html#method.is_unicast_link_local)
+- [core::ptr::with\_exposed\_provenance](https://doc.rust-lang.org/stable/core/ptr/fn.with_exposed_provenance.html)
+- [core::ptr::with\_exposed\_provenance\_mut](https://doc.rust-lang.org/stable/core/ptr/fn.with_exposed_provenance_mut.html)
+- [\<ptr\>::addr](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.addr)
+- [\<ptr\>::expose\_provenance](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.expose_provenance)
+- [\<ptr\>::with\_addr](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.with_addr)
+- [\<ptr\>::map\_addr](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.map_addr)
+- [\<int\>::isqrt](https://doc.rust-lang.org/stable/core/primitive.i32.html#method.isqrt)
+- [\<int\>::checked\_isqrt](https://doc.rust-lang.org/stable/core/primitive.i32.html#method.checked_isqrt)
+- [\<uint\>::isqrt](https://doc.rust-lang.org/stable/core/primitive.u32.html#method.isqrt)
+- [NonZero::isqrt](https://doc.rust-lang.org/stable/core/num/struct.NonZero.html#impl-NonZero%3Cu128%3E/method.isqrt)
+- [core::ptr::without\_provenance](https://doc.rust-lang.org/stable/core/ptr/fn.without_provenance.html)
+- [core::ptr::without\_provenance\_mut](https://doc.rust-lang.org/stable/core/ptr/fn.without_provenance_mut.html)
+- [core::ptr::dangling](https://doc.rust-lang.org/stable/core/ptr/fn.dangling.html)
+- [core::ptr::dangling\_mut](https://doc.rust-lang.org/stable/core/ptr/fn.dangling_mut.html)
+- [Pin::as\_deref\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.as_deref_mut)
+These APIs are now stable in const contexts
+
+- [AtomicBool::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicBool.html#method.from_ptr)
+- [AtomicPtr::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicPtr.html#method.from_ptr)
+- [AtomicU8::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicU8.html#method.from_ptr)
+- [AtomicU16::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicU16.html#method.from_ptr)
+- [AtomicU32::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicU32.html#method.from_ptr)
+- [AtomicU64::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicU64.html#method.from_ptr)
+- [AtomicUsize::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicUsize.html#method.from_ptr)
+- [AtomicI8::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicI8.html#method.from_ptr)
+- [AtomicI16::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicI16.html#method.from_ptr)
+- [AtomicI32::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicI32.html#method.from_ptr)
+- [AtomicI64::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicI64.html#method.from_ptr)
+- [AtomicIsize::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicIsize.html#method.from_ptr)
+- [\<ptr\>::is\_null](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.is_null-1)
+- [\<ptr\>::as\_ref](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.as_ref-1)
+- [\<ptr\>::as\_mut](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.as_mut)
+- [Pin::new](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.new)
+- [Pin::new\_unchecked](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.new_unchecked)
+- [Pin::get\_ref](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.get_ref)
+- [Pin::into\_ref](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.into_ref)
+- [Pin::get\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.get_mut)
+- [Pin::get\_unchecked\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.get_unchecked_mut)
+- [Pin::static\_ref](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.static_ref)
+- [Pin::static\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.static_mut)
+### Other changes
+
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.84.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-184-2025-01-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-184)\.
+
+## Contributors to 1\.84\.0
+
+Many people came together to create Rust 1\.84\.0\. We couldn't have done it without all of you\. [Thanks\!](https://thanks.rust-lang.org/rust/1.84.0/)

--- a/test-pages/readability/arxiv/expected.md
+++ b/test-pages/readability/arxiv/expected.md
@@ -1,0 +1,22 @@
+## Computer Science \> Information Retrieval
+
+**arXiv:2501\.16450** \(cs\)
+
+Authors:[Hamed Firooz](https://arxiv.org/search/cs?searchtype=author&query=Firooz,+H), [Maziar Sanjabi](https://arxiv.org/search/cs?searchtype=author&query=Sanjabi,+M), [Adrian Englhardt](https://arxiv.org/search/cs?searchtype=author&query=Englhardt,+A), [Aman Gupta](https://arxiv.org/search/cs?searchtype=author&query=Gupta,+A), [Ben Levine](https://arxiv.org/search/cs?searchtype=author&query=Levine,+B), [Dre Olgiati](https://arxiv.org/search/cs?searchtype=author&query=Olgiati,+D), [Gungor Polatkan](https://arxiv.org/search/cs?searchtype=author&query=Polatkan,+G), [Iuliia Melnychuk](https://arxiv.org/search/cs?searchtype=author&query=Melnychuk,+I), [Karthik Ramgopal](https://arxiv.org/search/cs?searchtype=author&query=Ramgopal,+K), [Kirill Talanine](https://arxiv.org/search/cs?searchtype=author&query=Talanine,+K), [Kutta Srinivasan](https://arxiv.org/search/cs?searchtype=author&query=Kutta), [Luke Simon](https://arxiv.org/search/cs?searchtype=author&query=Simon,+L), [Natesh Sivasubramoniapillai](https://arxiv.org/search/cs?searchtype=author&query=Sivasubramoniapillai,+N), [Necip Fazil Ayan](https://arxiv.org/search/cs?searchtype=author&query=Ayan,+N+F), [Qingquan Song](https://arxiv.org/search/cs?searchtype=author&query=Song,+Q), [Samira Sriram](https://arxiv.org/search/cs?searchtype=author&query=Samira), [Souvik Ghosh](https://arxiv.org/search/cs?searchtype=author&query=Ghosh,+S), [Tao Song](https://arxiv.org/search/cs?searchtype=author&query=Song,+T), [Vignesh Kothapalli](https://arxiv.org/search/cs?searchtype=author&query=Kothapalli,+V), [Xiaoling Zhai](https://arxiv.org/search/cs?searchtype=author&query=Zhai,+X), [Ya Xu](https://arxiv.org/search/cs?searchtype=author&query=Xu,+Y), [Yu Wang](https://arxiv.org/search/cs?searchtype=author&query=Wang,+Y), [Yun Dai](https://arxiv.org/search/cs?searchtype=author&query=Dai,+Y)
+
+[View PDF](/pdf/2501.16450) [HTML \(experimental\)](https://arxiv.org/html/2501.16450v1)
+
+> Abstract:Ranking and recommendation systems are the foundation for numerous online experiences, ranging from search results to personalized content delivery\. These systems have evolved into complex, multilayered architectures that leverage vast datasets and often incorporate thousands of predictive models\. The maintenance and enhancement of these models is a labor intensive process that requires extensive feature engineering\. This approach not only exacerbates technical debt but also hampers innovation in extending these systems to emerging problem domains\. In this report, we present our research to address these challenges by utilizing a large foundation model with a textual interface for ranking and recommendation tasks\. We illustrate several key advantages of our approach: \(1\) a single model can manage multiple predictive tasks involved in ranking and recommendation, \(2\) decoder models with textual interface due to their comprehension of reasoning capabilities, can generalize to new recommendation surfaces and out-of-domain problems, and \(3\) by employing natural language interfaces for task definitions and verbalizing member behaviors and their social connections, we eliminate the need for feature engineering and the maintenance of complex directed acyclic graphs of model dependencies\. We introduce our research pre-production model, 360Brew V1\.0, a 150B parameter, decoder-only model that has been trained and fine-tuned on LinkedIn's data and tasks\. This model is capable of solving over 30 predictive tasks across various segments of the LinkedIn platform, achieving performance levels comparable to or exceeding those of current production systems based on offline metrics, without task-specific fine-tuning\. Notably, each of these tasks is conventionally addressed by dedicated models that have been developed and maintained over multiple years by teams of a similar or larger size than our own\.
+
+
+|   |   |
+| - | - |
+| Subjects: | Information Retrieval \(cs\.IR\); Artificial Intelligence \(cs\.AI\) |
+| Cite as: | [arXiv:2501\.16450](https://arxiv.org/abs/2501.16450) \[cs\.IR\] |
+|  | \(or [arXiv:2501\.16450v1](https://arxiv.org/abs/2501.16450v1) \[cs\.IR\] for this version\) |
+|  | [https://doi\.org/10\.48550/arXiv\.2501\.16450](https://doi.org/10.48550/arXiv.2501.16450) arXiv-issued DOI via DataCite |
+
+## Submission history
+
+From: Maziar Sanjabi \[[view email](/show-email/fa91fd8b/2501.16450)\]
+**\[v1\]** Mon, 27 Jan 2025 19:14:52 UTC \(1,931 KB\)

--- a/tests/alt.rs
+++ b/tests/alt.rs
@@ -2,11 +2,15 @@ mod common;
 
 use std::fs;
 
-use common::test_alt_formatted_text;
+use common::test_alt_text;
 
 #[test]
 fn test_alt_formatted_last_fail() {
-    test_alt_formatted_text("./test-pages/alt/arxiv");
+    test_alt_text(
+        "./test-pages/alt/arxiv",
+        dom_smoothie::TextMode::Formatted,
+        "expected_alt.txt",
+    );
 }
 
 #[test]
@@ -14,6 +18,15 @@ fn table_test_alt_formatted_text() {
     let paths = fs::read_dir("./test-pages/alt").unwrap();
     for p in paths {
         let pp = p.unwrap().path();
-        test_alt_formatted_text(pp);
+        test_alt_text(pp, dom_smoothie::TextMode::Formatted, "expected_alt.txt");
+    }
+}
+
+#[test]
+fn table_test_alt_markdown() {
+    let paths = fs::read_dir("./test-pages/alt").unwrap();
+    for p in paths {
+        let pp = p.unwrap().path();
+        test_alt_text(pp, dom_smoothie::TextMode::Markdown, "expected.md");
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -21,17 +21,17 @@ struct ExpectedMetadata {
     readerable: bool,
 }
 
-pub(crate) fn test_alt_formatted_text<P>(test_path: P)
+pub(crate) fn test_alt_text<P>(test_path: P, text_mode: TextMode, expected_filename: &str)
 where
     P: AsRef<Path>,
 {
     let base_path = test_path.as_ref();
     let source_path = base_path.join("source.html");
-    let expected_path = base_path.join("expected_alt.txt");
+    let expected_path = base_path.join(expected_filename);
     // for more options check the documentation
     let cfg = Config {
         candidate_select_mode: CandidateSelectMode::DomSmoothie,
-        text_mode: TextMode::Formatted,
+        text_mode,
         ..Default::default()
     };
 


### PR DESCRIPTION
- `Readability::parse` can now output text as `Markdown` in `Article::text_content` when `Config::text_mode` is set to `TextMode::Markdown`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Markdown text output, offering an additional option for cleaner, formatted article content.
  
- **Documentation**
  - Updated guides and examples to include instructions on enabling the new Markdown formatting option and clarified text mode configurations.
  
- **Tests**
  - Expanded test cases to verify both formatted and Markdown text outputs for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->