### PR TITLE
Changed the handling of the empty `<a>` elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Link elements (`<a>`) without an `href` attribute and without child nodes are now removed from the article content during post-processing.
+- Changed how phrasing content determines wrapping some `<div>` element children with a `<p>` element. Now the element must contain some nodes to be wrapped.
+
 ## [0.7.0] - 2025-03-03
 
 ### Added

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -157,6 +157,9 @@ impl Readability {
 }
 
 fn pre_filter_document(doc: &Document, metadata: &mut Metadata) {
+    // Mozilla's implementation performs filtering for each approach of grabbing the article.
+    // However, I believe it is better to do it only once. Additionally, there is a lot of logic that relies 
+    // on a certain element which is going to be removed in the next iteration.
     let body_sel = doc.select_single("body");
     // html5ever always puts body element, even if it wasn't in the document's contents
     let root_node = body_sel.nodes().first().unwrap();

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -158,7 +158,7 @@ impl Readability {
 
 fn pre_filter_document(doc: &Document, metadata: &mut Metadata) {
     // Mozilla's implementation performs filtering for each approach of grabbing the article.
-    // However, I believe it is better to do it only once. Additionally, there is a lot of logic that relies 
+    // However, I believe it is better to do it only once. Additionally, there is a lot of logic that relies
     // on a certain element which is going to be removed in the next iteration.
     let body_sel = doc.select_single("body");
     // html5ever always puts body element, even if it wasn't in the document's contents

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -190,7 +190,7 @@ fn pre_filter_document(doc: &Document, metadata: &mut Metadata) {
 
         if metadata.byline.is_none() && is_valid_byline(&node) {
             let byline = if let Some(item_prop_name) = Selection::from(node.clone())
-                .select("[itemprop=name]")
+                .select_single("[itemprop=name]")
                 .nodes()
                 .first()
             {
@@ -452,11 +452,10 @@ fn assign_article_node(tc: &NodeRef, article_content: &NodeRef) {
                 // Turn it into a div so it doesn't get filtered out later by accident.
                 sibling.rename("div");
             }
-
             article_content.append_child(&sibling.id);
         }
-        tc_parent.append_child(article_content);
     }
+    tc_parent.append_child(article_content);
 }
 
 /// Find a better top candidate across other candidates in a way that `mozilla/readability` does.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -51,10 +51,10 @@ pub(crate) fn is_phrasing_content(node: &Node) -> bool {
         return true;
     }
 
-    if matches!(node_name, "a" | "del" | "ins")
-        && node.children().into_iter().all(|n| is_phrasing_content(&n))
-    {
-        return true;
+    if matches!(node_name, "a" | "del" | "ins") {
+        // There is no big sense to consider link content as phrasing content if they doesn't have children element.
+        let children = node.children();
+        return !children.is_empty() && children.into_iter().all(|n| is_phrasing_content(&n))
     }
 
     false

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -62,7 +62,7 @@ pub(crate) fn is_phrasing_content(node: &Node) -> bool {
 
 pub(crate) fn is_whitespace(node: &Node) -> bool {
     if node.is_text() {
-        return node.text().trim().is_empty();
+        return !is_nonempty_text(node);
     }
     // only an element node has a node_name
     MINI_BR.match_node(node)
@@ -172,14 +172,12 @@ pub(crate) fn has_single_tag_inside_element(node: &Node, tag: &str) -> bool {
         return false;
     }
 
-    !node.children_it(false).any(|n| is_empty_text(&n))
+    !node.children_it(false).any(|n| is_nonempty_text(&n))
 }
 
 pub(crate) fn is_element_without_content(node: &Node) -> bool {
     // since this function calls only for elements check `node.is_element()` is redundant
-
-    let has_text = node.descendants_it().any(|n| is_empty_text(&n));
-
+    let has_text = node.descendants_it().any(|n| is_nonempty_text(&n));
     if has_text {
         return false;
     }
@@ -233,7 +231,7 @@ pub(crate) fn is_probably_visible(node: &Node) -> bool {
     true
 }
 
-fn is_empty_text(node: &Node) -> bool {
+fn is_nonempty_text(node: &Node) -> bool {
     node.query_or(false, |t| {
         if let NodeData::Text { ref contents } = t.data {
             !contents.trim().is_empty()

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -54,7 +54,7 @@ pub(crate) fn is_phrasing_content(node: &Node) -> bool {
     if matches!(node_name, "a" | "del" | "ins") {
         // There is no big sense to consider link content as phrasing content if they doesn't have children element.
         let children = node.children();
-        return !children.is_empty() && children.into_iter().all(|n| is_phrasing_content(&n))
+        return !children.is_empty() && children.into_iter().all(|n| is_phrasing_content(&n));
     }
 
     false

--- a/src/prep_article.rs
+++ b/src/prep_article.rs
@@ -131,7 +131,7 @@ fn should_clean_conditionally(node: &Node, tag: &str, flags: &FlagSet<GrabFlags>
 
         let should_remove = || {
             let is_figure_child = has_ancestor_tag::<NodePredicate>(node, "figure", None, None);
-            let p  = node.find_descendants("p").len() as f32;
+            let p = node.find_descendants("p").len() as f32;
             // TODO: `li` looks suspicious
             let li = node.find_descendants("li").len() as f32 - 100.0;
 

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -823,7 +823,7 @@ impl Readability {
     fn post_process_content(&self, root_sel: &Selection, base_url: Option<url::Url>) {
         // Readability cannot open relative uris so we convert them to absolute uris.
 
-        self.fix_js_links(root_sel);
+        self.fix_links(root_sel);
 
         self.fix_relative_uris(root_sel, base_url);
 
@@ -875,7 +875,7 @@ impl Readability {
         }
     }
 
-    fn fix_js_links(&self, root_sel: &Selection) {
+    fn fix_links(&self, root_sel: &Selection) {
         // Handle links with javascript: URIs, since
         // they won't work after scripts have been removed from the page.
         for a in root_sel.select_matcher(&MATCHER_JS_LINK).nodes().iter() {
@@ -893,6 +893,13 @@ impl Readability {
             } else {
                 a.remove_all_attrs();
                 a.rename("span");
+            }
+        }
+
+        // Handle links without href attributes.
+        for a in root_sel.select("a:not([href])").nodes().iter() {
+            if a.children().is_empty() {
+                a.remove_from_parent();
             }
         }
     }
@@ -1147,7 +1154,7 @@ mod tests {
             </body>
         </html>"#;
         let readability = Readability::from(contents);
-        readability.fix_js_links(&readability.doc.select("body"));
+        readability.fix_links(&readability.doc.select("body"));
         assert_eq!(readability.doc.select("a").length(), 1);
     }
 

--- a/test-pages/alt/mozilla_readability/expected.md
+++ b/test-pages/alt/mozilla_readability/expected.md
@@ -1,4 +1,8 @@
+## Readability\.js
+
 A standalone version of the readability library used for [Firefox Reader View](https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages)\.
+
+## Installation
 
 Readability is available on npm:
 
@@ -10,6 +14,8 @@ npm install @mozilla/readability
 
 You can then `require()` it, or for web-based projects, load the `Readability.js` script from your webpage\.
 
+## Basic usage
+
 To parse a document, you must create a new `Readability` object from a DOM document object, and then call the [parse\(\)](#parse) method\. Here's an example:
 
 
@@ -19,6 +25,10 @@ var article = new Readability(document).parse();
 
 
 If you use Readability in a web browser, you will likely be able to use a `document` reference from elsewhere \(e\.g\. fetched via XMLHttpRequest, in a same-origin `<iframe>` you have access to, etc\.\)\. In Node\.js, you can [use an external DOM library](#nodejs-usage)\.
+
+## API Reference
+
+### `new Readability(document, options)`
 
 The `options` object accepts a number of properties, all optional:
 
@@ -32,6 +42,8 @@ The `options` object accepts a number of properties, all optional:
 - `serializer` \(function, default `el => el.innerHTML`\) controls how the `content` property returned by the `parse()` method is produced from the root DOM element\. It may be useful to specify the `serializer` as the identity function \(`el => el`\) to obtain a DOM element instead of a string for `content` if you plan to process it further\.
 - `allowedVideoRegex` \(RegExp, default `undefined` \): a regular expression that matches video URLs that should be allowed to be included in the article content\. If `undefined`, the [default regex](https://github.com/mozilla/readability/blob/8e8ec27cd2013940bc6f3cc609de10e35a1d9d86/Readability.js#L133) is applied\.
 - `linkDensityModifier` \(number, default `0`\): a number that is added to the base link density threshold during the shadiness checks\. This can be used to penalize nodes with a high link density or vice versa\.
+### `parse()`
+
 Returns an object containing the following properties:
 
 - `title`: article title;
@@ -52,6 +64,8 @@ var documentClone = document.cloneNode(true);
 var article = new Readability(documentClone).parse();
 ```
 
+
+### `isProbablyReaderable(document, options)`
 
 A quick-and-dirty way of figuring out if it's plausible that the contents of a given document are suitable for processing with Readability\. It is likely to produce both false positives and false negatives\. The reason it exists is to avoid bogging down a time-sensitive process \(like loading and showing the user a webpage\) with the complex logic in the core of Readability\. Improvements to its logic \(while not deteriorating its performance\) are very welcome\.
 
@@ -74,6 +88,8 @@ if (isProbablyReaderable(document)) {
 ```
 
 
+## Node\.js usage
+
 Since Node\.js does not come with its own DOM implementation, we rely on external libraries like [jsdom](https://github.com/jsdom/jsdom)\. Here's an example using `jsdom` to obtain a DOM document object:
 
 
@@ -92,9 +108,15 @@ Remember to pass the page's URI as the `url` option in the `JSDOM` constructor \
 
 `jsdom` has the ability to run the scripts included in the HTML and fetch remote resources\. For security reasons these are [disabled by default](https://github.com/jsdom/jsdom#executing-scripts), and we **strongly** recommend you keep them that way\.
 
+## Security
+
 If you're going to use Readability with untrusted input \(whether in HTML or DOM form\), we **strongly** recommend you use a sanitizer library like [DOMPurify](https://github.com/cure53/DOMPurify) to avoid script injection when you use the output of Readability\. We would also recommend using [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to add further defense-in-depth restrictions to what you allow the resulting content to do\. The Firefox integration of reader mode uses both of these techniques itself\. Sanitizing unsafe content out of the input is explicitly not something we aim to do as part of Readability itself - there are other good sanitizer libraries out there, use them\!
 
+## Contributing
+
 Please see our [Contributing](/mozilla/readability/blob/main/CONTRIBUTING.md) document\.
+
+## License
 
 
 ```

--- a/test-pages/alt/mozilla_readability/expected_alt.txt
+++ b/test-pages/alt/mozilla_readability/expected_alt.txt
@@ -1,4 +1,8 @@
+Readability.js
+
 A standalone version of the readability library used for Firefox Reader View.
+
+Installation
 
 Readability is available on npm:
 
@@ -6,11 +10,17 @@ npm install @mozilla/readability
 
 You can then require() it, or for web-based projects, load the Readability.js script from your webpage.
 
+Basic usage
+
 To parse a document, you must create a new Readability object from a DOM document object, and then call the parse() method. Here's an example:
 
 var article = new Readability(document).parse();
 
 If you use Readability in a web browser, you will likely be able to use a document reference from elsewhere (e.g. fetched via XMLHttpRequest, in a same-origin <iframe> you have access to, etc.). In Node.js, you can use an external DOM library.
+
+API Reference
+
+new Readability(document, options)
 
 The options object accepts a number of properties, all optional:
 
@@ -25,6 +35,8 @@ serializer (function, default el => el.innerHTML) controls how the content prope
 allowedVideoRegex (RegExp, default undefined ): a regular expression that matches video URLs that should be allowed to be included in the article content. If undefined, the default regex is applied.
 linkDensityModifier (number, default 0): a number that is added to the base link density threshold during the shadiness checks. This can be used to penalize nodes with a high link density or vice versa.
 
+
+parse()
 
 Returns an object containing the following properties:
 
@@ -45,6 +57,8 @@ The parse() method works by modifying the DOM. This removes some elements in the
 var documentClone = document.cloneNode(true);
 var article = new Readability(documentClone).parse();
 
+isProbablyReaderable(document, options)
+
 A quick-and-dirty way of figuring out if it's plausible that the contents of a given document are suitable for processing with Readability. It is likely to produce both false positives and false negatives. The reason it exists is to avoid bogging down a time-sensitive process (like loading and showing the user a webpage) with the complex logic in the core of Readability. Improvements to its logic (while not deteriorating its performance) are very welcome.
 
 The options object accepts a number of properties, all optional:
@@ -64,6 +78,8 @@ if (isProbablyReaderable(document)) {
     let article = new Readability(document).parse();
 }
 
+Node.js usage
+
 Since Node.js does not come with its own DOM implementation, we rely on external libraries like jsdom. Here's an example using jsdom to obtain a DOM document object:
 
 var { Readability } = require('@mozilla/readability');
@@ -78,9 +94,15 @@ Remember to pass the page's URI as the url option in the JSDOM constructor (as s
 
 jsdom has the ability to run the scripts included in the HTML and fetch remote resources. For security reasons these are disabled by default, and we strongly recommend you keep them that way.
 
+Security
+
 If you're going to use Readability with untrusted input (whether in HTML or DOM form), we strongly recommend you use a sanitizer library like DOMPurify to avoid script injection when you use the output of Readability. We would also recommend using CSP to add further defense-in-depth restrictions to what you allow the resulting content to do. The Firefox integration of reader mode uses both of these techniques itself. Sanitizing unsafe content out of the input is explicitly not something we aim to do as part of Readability itself - there are other good sanitizer libraries out there, use them!
 
+Contributing
+
 Please see our Contributing document.
+
+License
 
 Copyright (c) 2010 Arc90 Inc
 

--- a/test-pages/readability/google-sre-book-1/expected.html
+++ b/test-pages/readability/google-sre-book-1/expected.html
@@ -5,7 +5,7 @@
         <section data-type="sect1" id="definitions-2ksZhN">
             <h2> Definitions </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="terminology" id="id-DnC1SWFMhD"></a>There’s no uniformly shared vocabulary for discussing all topics related to monitoring. Even within Google, usage of the following terms varies, but the most common interpretations are listed here.
+                There’s no uniformly shared vocabulary for discussing all topics related to monitoring. Even within Google, usage of the following terms varies, but the most common interpretations are listed here.
             </p>
             <dl>
                 <dd>
@@ -13,33 +13,33 @@
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="white-box monitoring" id="id-9nCjSDS4tZILhX"></a>Monitoring based on metrics exposed by the internals of the system, including logs, interfaces like the Java Virtual Machine Profiling Interface, or an HTTP handler that emits internal statistics.
+                        Monitoring based on metrics exposed by the internals of the system, including logs, interfaces like the Java Virtual Machine Profiling Interface, or an HTTP handler that emits internal statistics.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="black-box monitoring" id="id-zdCxSrSgTWIdhb"></a>Testing externally visible behavior as a user would see it.
+                        Testing externally visible behavior as a user would see it.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="dashboards" data-secondary="defined" id="id-VMCPS2SribIkh4"></a>An application (usually web-based) that provides a summary view of a service’s core metrics. A dashboard may have filters, selectors, and so on, but is prebuilt to expose the metrics most important to its users. The dashboard might also display team information such as ticket queue length, a list of high-priority bugs, the current on-call engineer for a given area of responsibility, or recent pushes.
+                        An application (usually web-based) that provides a summary view of a service’s core metrics. A dashboard may have filters, selectors, and so on, but is prebuilt to expose the metrics most important to its users. The dashboard might also display team information such as ticket queue length, a list of high-priority bugs, the current on-call engineer for a given area of responsibility, or recent pushes.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="alerts" data-secondary="defined" id="id-wqC7SvSPUAIVhQ"></a>A notification intended to be read by a human and that is pushed to a system such as a bug or ticket queue, an email alias, or a pager. Respectively, these alerts are classified as <em>tickets</em>, <em>email alerts</em>,<sup><a data-type="noteref" id="id-LvQuvtYS7UvI8h4-marker" href="#id-LvQuvtYS7UvI8h4">22</a></sup> and <em>pages</em>.
+                        A notification intended to be read by a human and that is pushed to a system such as a bug or ticket queue, an email alias, or a pager. Respectively, these alerts are classified as <em>tickets</em>, <em>email alerts</em>,<sup><a data-type="noteref" id="id-LvQuvtYS7UvI8h4-marker" href="#id-LvQuvtYS7UvI8h4">22</a></sup> and <em>pages</em>.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="root cause" data-secondary="defined" id="id-PnCpSaSKsgIjho"></a>A defect in a software or human system that, if repaired, instills confidence that this event won’t happen again in the same way. A given incident might have multiple root causes: for example, perhaps it was caused by a combination of insufficient process automation, software that crashed on bogus input, <em>and</em> insufficient testing of the script used to generate the configuration. Each of these factors might stand alone as a root cause, and each should be repaired.
+                        A defect in a software or human system that, if repaired, instills confidence that this event won’t happen again in the same way. A given incident might have multiple root causes: for example, perhaps it was caused by a combination of insufficient process automation, software that crashed on bogus input, <em>and</em> insufficient testing of the script used to generate the configuration. Each of these factors might stand alone as a root cause, and each should be repaired.
                     </p>
                 </dd>
                 <dt id="node-and-machine"> Node and machine </dt>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="machines" data-secondary="defined" id="id-XmC9SkSlfnI1hK"></a>Used interchangeably to indicate a single instance of a running kernel in either a physical server, virtual machine, or container. There might be multiple <em>services</em> worth monitoring on a single machine. The services may either be:
+                        Used interchangeably to indicate a single instance of a running kernel in either a physical server, virtual machine, or container. There might be multiple <em>services</em> worth monitoring on a single machine. The services may either be:
                     </p>
                     <ul>
                         <li>Related to each other: for example, a caching server and a web server </li>
@@ -55,7 +55,7 @@
         <section data-type="sect1" id="why-monitor-pWsBTZ">
             <h2> Why Monitor? </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="benefits of monitoring" id="id-kVCkSpFnTl"></a>There are many reasons to monitor a system, including:
+                There are many reasons to monitor a system, including:
             </p>
             <dl>
                 <dd>
@@ -69,7 +69,7 @@
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="dashboards" data-secondary="benefits of" id="id-rjCXSOS0iDIGT8"></a>Dashboards should answer basic questions about your service, and normally include some form of the four golden signals (discussed in <a data-type="xref" href="#xref_monitoring_golden-signals">The Four Golden Signals</a>).
+                        Dashboards should answer basic questions about your service, and normally include some form of the four golden signals (discussed in <a data-type="xref" href="#xref_monitoring_golden-signals">The Four Golden Signals</a>).
                     </p>
                 </dd>
                 <dd>
@@ -83,13 +83,13 @@
         <section data-type="sect1" id="setting-reasonable-expectations-for-monitoring-o8svcM">
             <h2> Setting Reasonable Expectations for Monitoring </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="setting expectations for" id="id-4nCqSYFQcE"></a>Monitoring a complex application is a significant engineering endeavor in and of itself. Even with substantial existing infrastructure for instrumentation, collection, display, and alerting in place, a Google SRE team with 10–12 members typically has one or sometimes two members whose primary assignment is to build and maintain monitoring systems for their service. This number has decreased over time as we generalize and centralize common monitoring infrastructure, but every SRE team typically has at least one “monitoring person.” (That being said, while it can be fun to have access to traffic graph dashboards and the like, SRE teams carefully avoid any situation that requires someone to “stare at a screen to watch for problems.”)
+                Monitoring a complex application is a significant engineering endeavor in and of itself. Even with substantial existing infrastructure for instrumentation, collection, display, and alerting in place, a Google SRE team with 10–12 members typically has one or sometimes two members whose primary assignment is to build and maintain monitoring systems for their service. This number has decreased over time as we generalize and centralize common monitoring infrastructure, but every SRE team typically has at least one “monitoring person.” (That being said, while it can be fun to have access to traffic graph dashboards and the like, SRE teams carefully avoid any situation that requires someone to “stare at a screen to watch for problems.”)
             </p>
             <p>
-                <a data-type="indexterm" data-primary="post hoc analysis" id="id-JnCDSjIVcG"></a>In general, Google has trended toward simpler and faster monitoring systems, with better tools for <em>post hoc</em> analysis. We avoid "magic" systems that try to learn thresholds or automatically detect causality. Rules that detect unexpected changes in end-user request rates are one counterexample; while these rules are still kept as simple as possible, they give a very quick detection of a very simple, specific, severe anomaly. Other uses of monitoring data such as capacity planning and traffic prediction can tolerate more fragility, and thus, more complexity. Observational experiments conducted over a very long time horizon (months or years) with a low sampling rate (hours or days) can also often tolerate more fragility because occasional missed samples won’t hide a long-running trend.
+                In general, Google has trended toward simpler and faster monitoring systems, with better tools for <em>post hoc</em> analysis. We avoid "magic" systems that try to learn thresholds or automatically detect causality. Rules that detect unexpected changes in end-user request rates are one counterexample; while these rules are still kept as simple as possible, they give a very quick detection of a very simple, specific, severe anomaly. Other uses of monitoring data such as capacity planning and traffic prediction can tolerate more fragility, and thus, more complexity. Observational experiments conducted over a very long time horizon (months or years) with a low sampling rate (hours or days) can also often tolerate more fragility because occasional missed samples won’t hide a long-running trend.
             </p>
             <p>
-                <a data-type="indexterm" data-primary="dependency hierarchies" id="id-9nCjSOtmcj"></a>Google SRE has experienced only limited success with complex dependency hierarchies. We seldom use rules such as, "If I know the database is slow, alert for a slow database; otherwise, alert for the website being generally slow." Dependency-reliant rules usually pertain to very stable parts of our system, such as our system for draining user traffic away from a datacenter. For example, "If a datacenter is drained, then don’t alert me on its latency" is one common datacenter alerting rule. Few teams at Google maintain complex dependency hierarchies because our infrastructure has a steady rate of continuous refactoring.
+                Google SRE has experienced only limited success with complex dependency hierarchies. We seldom use rules such as, "If I know the database is slow, alert for a slow database; otherwise, alert for the website being generally slow." Dependency-reliant rules usually pertain to very stable parts of our system, such as our system for draining user traffic away from a datacenter. For example, "If a datacenter is drained, then don’t alert me on its latency" is one common datacenter alerting rule. Few teams at Google maintain complex dependency hierarchies because our infrastructure has a steady rate of continuous refactoring.
             </p>
             <p> Some of the ideas described in this chapter are still aspirational: there is always room to move more rapidly from symptom to root cause(s), especially in ever-changing systems. So while this chapter sets out some goals for monitoring systems, and some ways to achieve these goals, it’s important that monitoring systems—especially the critical path from the onset of a production problem, through a page to a human, through basic triage and deep debugging—be kept simple and comprehensible by everyone on the team. </p>
             <p> Similarly, to keep noise low and signal high, the elements of your monitoring system that direct to a pager need to be very simple and robust. Rules that generate alerts for humans should be simple to understand and represent a clear failure. </p>
@@ -97,7 +97,7 @@
         <section data-type="sect1" id="symptoms-versus-causes-g0sEi4">
             <h2> Symptoms Versus Causes </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="symptoms vs. causes" id="id-JnCDSlFmiG"></a>Your monitoring system should address two questions: what’s broken, and why?
+                Your monitoring system should address two questions: what’s broken, and why?
             </p>
             <p> The "what’s broken" indicates the symptom; the "why" indicates a (possibly intermediate) cause. <a data-type="xref" href="#table_monitoring_symptoms">Table 6-1</a> lists some hypothetical symptoms and corresponding causes. </p>
             <table id="table_monitoring_symptoms">
@@ -162,7 +162,7 @@
         <section data-type="sect1" id="black-box-versus-white-box-q8sJuw">
             <h2> Black-Box Versus White-Box </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="blackbox vs. whitebox" id="id-9nCjSvFVuj"></a><a data-type="indexterm" data-primary="white-box monitoring" id="id-ZbC1FMFEu7"></a><a data-type="indexterm" data-primary="black-box monitoring" id="id-zdCXIGFvuy"></a>We combine heavy use of white-box monitoring with modest but critical uses of black-box monitoring. The simplest way to think about black-box monitoring versus white-box monitoring is that black-box monitoring is symptom-oriented and represents active—not predicted—problems: "The system isn’t working correctly, right now." White-box monitoring depends on the ability to inspect the innards of the system, such as logs or HTTP endpoints, with instrumentation. White-box monitoring therefore allows detection of imminent problems, failures masked by retries, and so forth.
+                We combine heavy use of white-box monitoring with modest but critical uses of black-box monitoring. The simplest way to think about black-box monitoring versus white-box monitoring is that black-box monitoring is symptom-oriented and represents active—not predicted—problems: "The system isn’t working correctly, right now." White-box monitoring depends on the ability to inspect the innards of the system, such as logs or HTTP endpoints, with instrumentation. White-box monitoring therefore allows detection of imminent problems, failures masked by retries, and so forth.
             </p>
             <p> Note that in a multilayered system, one person’s symptom is another person’s cause. For example, suppose that a database’s performance is slow. Slow database reads are a symptom for the database SRE who detects them. However, for the frontend SRE observing a slow website, the same slow database reads are a cause. Therefore, white-box monitoring is sometimes symptom-oriented, and sometimes cause-oriented, depending on just how informative your white-box is. </p>
             <p> When collecting telemetry for debugging, white-box monitoring is essential. If web servers seem slow on database-heavy requests, you need to know both how fast the web server perceives the database to be, and how fast the database believes itself to be. Otherwise, you can’t distinguish an actually slow database server from a network problem between your web server and your database. </p>
@@ -171,27 +171,27 @@
         <section data-type="sect1" id="xref_monitoring_golden-signals">
             <h2> The Four Golden Signals </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="four golden signals of" id="id-ZbCxSMFjU7"></a>The four golden signals of monitoring are latency, traffic, errors, and saturation. If you can only measure four metrics of your user-facing system, focus on these four.
+                The four golden signals of monitoring are latency, traffic, errors, and saturation. If you can only measure four metrics of your user-facing system, focus on these four.
             </p>
             <dl>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="service latency" data-secondary="monitoring for" id="id-yYCASJS9FKIWUb"></a><a data-type="indexterm" data-primary="latency" data-secondary="monitoring for" id="id-VMCpF2SXFbIwU4"></a><a data-type="indexterm" data-primary="request latency" id="id-rjCeIOSKFDIaU8"></a><a data-type="indexterm" data-primary="user requests" data-secondary="request latency monitoring" id="id-wqCDtvSGFAIMUQ"></a>The time it takes to service a request. It’s important to distinguish between the latency of successful requests and the latency of failed requests. For example, an HTTP 500 error triggered due to loss of connection to a database or other critical backend might be served very quickly; however, as an HTTP 500 error indicates a failed request, factoring 500s into your overall latency might result in misleading calculations. On the other hand, a slow error is even worse than a fast error! Therefore, it’s important to track error latency, as opposed to just filtering out errors.
+                        The time it takes to service a request. It’s important to distinguish between the latency of successful requests and the latency of failed requests. For example, an HTTP 500 error triggered due to loss of connection to a database or other critical backend might be served very quickly; however, as an HTTP 500 error indicates a failed request, factoring 500s into your overall latency might result in misleading calculations. On the other hand, a slow error is even worse than a fast error! Therefore, it’s important to track error latency, as opposed to just filtering out errors.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="user requests" data-secondary="traffic analysis" id="id-rjCXSOSxtDIaU8"></a><a data-type="indexterm" data-primary="traffic analysis" id="id-wqC4FvSBtAIMUQ"></a>A measure of how much demand is being placed on your system, measured in a high-level system-specific metric. For a web service, this measurement is usually HTTP requests per second, perhaps broken out by the nature of the requests (e.g., static versus dynamic content). For an audio streaming system, this measurement might focus on network I/O rate or concurrent sessions. For a key-value storage system, this measurement might be transactions and retrievals per <span>second</span>.
+                        A measure of how much demand is being placed on your system, measured in a high-level system-specific metric. For a web service, this measurement is usually HTTP requests per second, perhaps broken out by the nature of the requests (e.g., static versus dynamic content). For an audio streaming system, this measurement might focus on network I/O rate or concurrent sessions. For a key-value storage system, this measurement might be transactions and retrievals per <span>second</span>.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="error rates" id="id-x1C4SjSlTLIMUJ"></a><a data-type="indexterm" data-primary="user requests" data-secondary="monitoring failures" id="id-PnCxFaS0TgIVUo"></a>The rate of requests that fail, either explicitly (e.g., HTTP 500s), implicitly (for example, an HTTP 200 success response, but coupled with the wrong content), or by policy (for example, "If you committed to one-second response times, any request over one second is an error"). Where protocol response codes are insufficient to express all failure conditions, secondary (internal) protocols may be necessary to track partial failure modes. Monitoring these cases can be drastically different: catching HTTP 500s at your load balancer can do a decent job of catching all completely failed requests, while only end-to-end system tests can detect that you’re serving the wrong content.
+                        The rate of requests that fail, either explicitly (e.g., HTTP 500s), implicitly (for example, an HTTP 200 success response, but coupled with the wrong content), or by policy (for example, "If you committed to one-second response times, any request over one second is an error"). Where protocol response codes are insufficient to express all failure conditions, secondary (internal) protocols may be necessary to track partial failure modes. Monitoring these cases can be drastically different: catching HTTP 500s at your load balancer can do a decent job of catching all completely failed requests, while only end-to-end system tests can detect that you’re serving the wrong content.
                     </p>
                 </dd>
                 <dd>
                     <p>
-                        <a data-type="indexterm" data-primary="saturation" id="id-OnCNS2S4iDIYU8"></a>How "full" your service is. A measure of your system fraction, emphasizing the resources that are most constrained (e.g., in a memory-constrained system, show memory; in an I/O-constrained system, show I/O). Note that many systems degrade in performance before they achieve 100% utilization, so having a utilization target is essential.
+                        How "full" your service is. A measure of your system fraction, emphasizing the resources that are most constrained (e.g., in a memory-constrained system, show memory; in an I/O-constrained system, show I/O). Note that many systems degrade in performance before they achieve 100% utilization, so having a utilization target is essential.
                     </p>
                     <p> In complex systems, saturation can be supplemented with higher-level load measurement: can your service properly handle double the traffic, handle only 10% more traffic, or handle even less traffic than it currently receives? For very simple services that have no parameters that alter the complexity of the request (e.g., "Give me a nonce" or "I need a globally unique monotonic integer") that rarely change configuration, a static value from a load test might be adequate. As discussed in the previous paragraph, however, most services need to use indirect signals like CPU utilization or network bandwidth that have a known upper bound. Latency increases are often a leading indicator of saturation. Measuring your 99th percentile response time over some small window (e.g., one minute) can give a very early signal of saturation. </p>
                     <p> Finally, saturation is also concerned with predictions of impending saturation, such as "It looks like your database will fill its hard drive in 4 hours." </p>
@@ -202,14 +202,14 @@
         <section data-type="sect1" id="worrying-about-your-tail-or-instrumentation-and-performance-Yms9Ck">
             <h2> Worrying About Your Tail (or, Instrumentation and Performance) </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="instrumentation and performance" id="id-zdCxSGFQCy"></a><a data-type="indexterm" data-primary="performance" data-secondary="monitoring" id="id-yYCyFpFdCr"></a>When building a monitoring system from scratch, it’s tempting to design a system based upon the mean of some quantity: the mean latency, the mean CPU usage of your nodes, or the mean fullness of your databases. The danger presented by the latter two cases is obvious: CPUs and databases can easily be utilized in a very imbalanced way. The same holds for latency. If you run a web service with an average latency of 100 ms at 1,000 requests per second, 1% of requests might easily take 5 seconds.<sup><a data-type="noteref" id="id-QQLuAIXFxCz-marker" href="#id-QQLuAIXFxCz">23</a></sup> If your users depend on several such web services to render their page, the 99th percentile of one backend can easily become the median response of your <span>frontend</span>.
+                When building a monitoring system from scratch, it’s tempting to design a system based upon the mean of some quantity: the mean latency, the mean CPU usage of your nodes, or the mean fullness of your databases. The danger presented by the latter two cases is obvious: CPUs and databases can easily be utilized in a very imbalanced way. The same holds for latency. If you run a web service with an average latency of 100 ms at 1,000 requests per second, 1% of requests might easily take 5 seconds.<sup><a data-type="noteref" id="id-QQLuAIXFxCz-marker" href="#id-QQLuAIXFxCz">23</a></sup> If your users depend on several such web services to render their page, the 99th percentile of one backend can easily become the median response of your <span>frontend</span>.
             </p>
             <p> The simplest way to differentiate between a slow average and a very slow "tail" of requests is to collect request counts bucketed by latencies (suitable for rendering a histogram), rather than actual latencies: how many requests did I serve that took between 0 ms and 10 ms, between 10 ms and 30 ms, between 30 ms and 100 ms, between 100 ms and 300 ms, and so on? Distributing the histogram boundaries approximately exponentially (in this case by factors of roughly 3) is often an easy way to visualize the distribution of your requests. </p>
         </section>
         <section data-type="sect1" id="choosing-an-appropriate-resolution-for-measurements-vJsBsE">
             <h2> Choosing an Appropriate Resolution for Measurements </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="resolution" id="id-yYCASpFxsr"></a>Different aspects of a system should be measured with different levels of granularity. For example:
+                Different aspects of a system should be measured with different levels of granularity. For example:
             </p>
             <ul>
                 <li>Observing CPU load over the time span of a minute won’t reveal even quite long-lived spikes that drive high tail latencies. </li>
@@ -227,7 +227,7 @@
         <section data-type="sect1" id="as-simple-as-possible-no-simpler-lqskHx">
             <h2> As Simple as Possible, No Simpler </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="avoiding complexity in" id="id-VMCPSrFpHm"></a>Piling all these requirements on top of each other can add up to a very complex monitoring system—your system might end up with the following levels of complexity:
+                Piling all these requirements on top of each other can add up to a very complex monitoring system—your system might end up with the following levels of complexity:
             </p>
             <ul>
                 <li>Alerts on different latency thresholds, at different percentiles, on all kinds of different metrics </li>
@@ -247,7 +247,7 @@
             <h2> Tying These Principles Together </h2>
             <p> The principles discussed in this chapter can be tied together into a philosophy on monitoring and alerting that’s widely endorsed and followed within Google SRE teams. While this monitoring philosophy is a bit aspirational, it’s a good starting point for writing or reviewing a new alert, and it can help your organization ask the right questions, regardless of the size of your organization or the complexity of your service or system. </p>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="creating rules for" id="id-wqC7SDIvfj"></a>When creating rules for monitoring and alerting, asking the following questions can help you avoid false positives and pager burnout:<sup><a data-type="noteref" id="id-a82udF8IBfx-marker" href="#id-a82udF8IBfx">24</a></sup>
+                When creating rules for monitoring and alerting, asking the following questions can help you avoid false positives and pager burnout:<sup><a data-type="noteref" id="id-a82udF8IBfx-marker" href="#id-a82udF8IBfx">24</a></sup>
             </p>
             <ul>
                 <li>Does this rule detect <em>an otherwise undetected condition</em> that is urgent, actionable, and actively or imminently user-visible?<sup><a data-type="noteref" id="id-0vYuEFpSjSMtLfG-marker" href="#id-0vYuEFpSjSMtLfG">25</a></sup>
@@ -258,7 +258,7 @@
                 <li>Are other people getting paged for this issue, therefore rendering at least one of the pages unnecessary? </li>
             </ul>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="monitoring philosophy" id="id-PnCpSwhJfa"></a>These questions reflect a fundamental philosophy on pages and pagers:
+                These questions reflect a fundamental philosophy on pages and pagers:
             </p>
             <ul>
                 <li>Every time the pager goes off, I should be able to react with a sense of urgency. I can only react with a sense of urgency a few times a day before I become fatigued. </li>
@@ -271,12 +271,12 @@
         <section data-type="sect1" id="monitoring-for-the-long-term-NbsNS8">
             <h2> Monitoring for the Long Term </h2>
             <p>
-                <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="challenges of" id="id-wqC7SPFMSj"></a>In modern production systems, monitoring systems track an ever-evolving system with changing software architecture, load characteristics, and performance targets. An alert that’s currently exceptionally rare and hard to automate might become frequent, perhaps even meriting a hacked-together script to resolve it. At this point, someone should find and eliminate the root causes of the problem; if such resolution isn’t possible, the alert response deserves to be fully automated.
+                In modern production systems, monitoring systems track an ever-evolving system with changing software architecture, load characteristics, and performance targets. An alert that’s currently exceptionally rare and hard to automate might become frequent, perhaps even meriting a hacked-together script to resolve it. At this point, someone should find and eliminate the root causes of the problem; if such resolution isn’t possible, the alert response deserves to be fully automated.
             </p>
             <p> It’s important that decisions about monitoring be made with long-term goals in mind. Every page that happens today distracts a human from improving the system for tomorrow, so there is often a case for taking a short-term hit to availability or performance in order to improve the long-term outlook for the system. Let’s take a look at two case studies that illustrate this trade-off. </p>
             <section data-type="sect2" id="bigtable-sre-a-tale-of-over-alerting-dbsXtjSM">
                 <p>
-                    <a data-type="indexterm" id="MDSbig6" data-primary="monitoring distributed systems" data-secondary="case studies"></a><a data-type="indexterm" data-primary="Bigtable" id="id-XmCpFOFytySv"></a>Google’s internal infrastructure is typically offered and measured against a service level objective (SLO; see <a data-type="xref" href="http://fakehost/sre/sre-book/chapters/service-level-objectives">Service Level Objectives</a>). Many years ago, the Bigtable service’s SLO was based on a synthetic well-behaved client’s mean performance. Because of problems in Bigtable and lower layers of the storage stack, the mean performance was driven by a "large" tail: the worst 5% of requests were often significantly slower than the rest.
+                    Google’s internal infrastructure is typically offered and measured against a service level objective (SLO; see <a data-type="xref" href="http://fakehost/sre/sre-book/chapters/service-level-objectives">Service Level Objectives</a>). Many years ago, the Bigtable service’s SLO was based on a synthetic well-behaved client’s mean performance. Because of problems in Bigtable and lower layers of the storage stack, the mean performance was driven by a "large" tail: the worst 5% of requests were often significantly slower than the rest.
                 </p>
                 <p> Email alerts were triggered as the SLO approached, and paging alerts were triggered when the SLO was exceeded. Both types of alerts were firing voluminously, consuming unacceptable amounts of engineering time: the team spent significant amounts of time triaging the alerts to find the few that were really actionable, and we often missed the problems that actually affected users, because so few of them did. Many of the pages were non-urgent, due to well-understood problems in the infrastructure, and had either rote responses or received no response. </p>
                 <p> To remedy the situation, the team used a three-pronged approach: while making great efforts to improve the performance of Bigtable, we also temporarily dialed back our SLO target, using the 75th percentile request latency. We also disabled email alerts, as there were so many that spending time diagnosing them was infeasible. </p>
@@ -284,17 +284,17 @@
             </section>
             <section data-type="sect2" id="gmail-predictable-scriptable-responses-from-humans-BVs1h4SD">
                 <p>
-                    <a data-type="indexterm" data-primary="Gmail" id="id-XmC9SOFZhySv"></a>In the very early days of Gmail, the service was built on a retrofitted distributed process management system called Workqueue, which was originally created for batch processing of pieces of the search index. Workqueue was "adapted" to long-lived processes and subsequently applied to Gmail, but certain bugs in the relatively opaque codebase in the scheduler proved hard to beat.
+                    In the very early days of Gmail, the service was built on a retrofitted distributed process management system called Workqueue, which was originally created for batch processing of pieces of the search index. Workqueue was "adapted" to long-lived processes and subsequently applied to Gmail, but certain bugs in the relatively opaque codebase in the scheduler proved hard to beat.
                 </p>
                 <p> At that time, the Gmail monitoring was structured such that alerts fired when individual tasks were “de-scheduled” by Workqueue. This setup was less than ideal because even at that time, Gmail had many, many thousands of tasks, each task representing a fraction of a percent of our users. We cared deeply about providing a good user experience for Gmail users, but such an alerting setup was unmaintainable. </p>
                 <p> To address this problem, Gmail SRE built a tool that helped “poke” the scheduler in just the right way to minimize impact to users. The team had several discussions about whether or not we should simply automate the entire loop from detecting the problem to nudging the rescheduler, until a better long-term solution was achieved, but some worried this kind of workaround would delay a real fix. </p>
                 <p> This kind of tension is common within a team, and often reflects an underlying mistrust of the team’s self-discipline: while some team members want to implement a “hack” to allow time for a proper fix, others worry that a hack will be forgotten or that the proper fix will be deprioritized indefinitely. This concern is credible, as it’s easy to build layers of unmaintainable technical debt by patching over problems instead of making real fixes. Managers and technical leaders play a key role in implementing true, long-term fixes by supporting and prioritizing potentially time-consuming long-term fixes even when the initial “pain” of paging subsides. </p>
-                <p> Pages with rote, algorithmic responses should be a red flag. Unwillingness on the part of your team to automate such pages implies that the team lacks confidence that they can clean up their technical debt. This is a major problem worth escalating.<a data-type="indexterm" data-primary="" data-startref="MDSbig6" id="id-oPCASqT2hLSk"></a>
+                <p> Pages with rote, algorithmic responses should be a red flag. Unwillingness on the part of your team to automate such pages implies that the team lacks confidence that they can clean up their technical debt. This is a major problem worth escalating.
                 </p>
             </section>
             <section data-type="sect2" id="the-long-run-MQsWTMS7">
                 <p>
-                    <a data-type="indexterm" data-primary="monitoring distributed systems" data-secondary="short- vs. long-term availability" id="id-jyCxSoFETNSd"></a>A common theme connects the previous examples of Bigtable and Gmail: a tension between short-term and long-term availability. Often, sheer force of effort can help a rickety system achieve high availability, but this path is usually short-lived and fraught with burnout and dependence on a small number of heroic team members. Taking a controlled, short-term decrease in availability is often a painful, but strategic trade for the long-run stability of the system. It’s important not to think of every page as an event in isolation, but to consider whether the overall <em>level</em> of paging leads toward a healthy, appropriately available system with a healthy, viable team and long-term outlook. We review statistics about page frequency (usually expressed as incidents per shift, where an incident might be composed of a few related pages) in quarterly reports with management, ensuring that decision makers are kept up to date on the pager load and overall health of their teams.
+                    A common theme connects the previous examples of Bigtable and Gmail: a tension between short-term and long-term availability. Often, sheer force of effort can help a rickety system achieve high availability, but this path is usually short-lived and fraught with burnout and dependence on a small number of heroic team members. Taking a controlled, short-term decrease in availability is often a painful, but strategic trade for the long-run stability of the system. It’s important not to think of every page as an event in isolation, but to consider whether the overall <em>level</em> of paging leads toward a healthy, appropriately available system with a healthy, viable team and long-term outlook. We review statistics about page frequency (usually expressed as incidents per shift, where an incident might be composed of a few related pages) in quarterly reports with management, ensuring that decision makers are kept up to date on the pager load and overall health of their teams.
                 </p>
             </section>
         </section>

--- a/test-pages/readability/lazy-image-2/expected.html
+++ b/test-pages/readability/lazy-image-2/expected.html
@@ -16,7 +16,7 @@
         <p> It’s a place in which xenocide is a commissioned service, and grievances are resolved with planetary apocalypses. Everything is chaotically connected to a dead race of avian prophetic poets fighting a war throughout the cosmos. It’s a dark place to visit. </p>
         <p> There are two purposes to this article: to explore the expansive lore of the <em>Metroid</em> universe – with speculation to fill in the gaps – and to exhibit some extraordinary <em>Metroid</em>-inspired art. All artwork is credited to its original source – follow the links to see further works of these spectacular artists. </p>
         <h3 id="h3288">
-            <a id=""></a>Notes on Speculation and Lore
+            Notes on Speculation and Lore
         </h3>
         <p> The games tell us much about this hostile universe, but there are a lot of unresolved story points. In response to these mysteries, the article will provide a healthy amount of speculation. You can consider the piece to be either a makeshift timeline illustrated with fan-artwork, or simply an enthusiastic attempt to reconcile the series continuity into a cohesive whole. The article is informed by the extensive research previously performed by its author. The approach taken regarding speculation is thus: The logical inclusion of probable events that resolve mysteries, while maintaining the themes of the series. </p>
         <p> Before we begin, let’s briefly revisit the five points of essential lore: </p>
@@ -45,17 +45,17 @@
             <em>(Metroid, Metroid II: Return of Samus)</em>
         </p>
         <h3 id="h3289">
-            <a id=""></a>Referencing
+            Referencing
         </h3>
         <p> Each story section includes one or more of the below superscript annotations, to help inform the reader as to where the lore or speculation comes from. A brief key: </p>
         <figure data-id="18zqfwc3l0k28gif" data-recommend-id="image://18zqfwc3l0k28gif" data-format="gif" data-width="640" data-height="128" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
         </figure>
         <p> With all that said, let us begin. </p>
         <h2 id="h3290">
-            <a id=""></a>Part One: The Wars in Heaven
+            Part One: The Wars in Heaven
         </h2>
         <h3 id="h3291">
-            <a id=""></a>The Living Planet
+            The Living Planet
         </h3>
         <figure data-id="18zqg21aub0sljpg" data-recommend-id="image://18zqg21aub0sljpg" data-format="jpg" data-width="640" data-height="488" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -119,7 +119,7 @@
         <p> With this find, the Chozo purpose on SkyTown was fulfilled. The race departed the facility, leaving the Elysians to continue their monitoring of the stars. The abandoned race of robots continued to launch satellites to try and rediscover the blue world, hopeful that such a discovery would herald the return of their Chozo creators. The Elysians searched unsuccessfully until Elysia’s endless storms eroded their civilisation into a rusted remnant. [MP3] </p>
         <p> The Chozo reconciled their vague discovery of a blue living planet with their prophecies of toxicity. On this distant world of poison, could creatures have evolved so vicious that they endangered the universe? [MP3 SP] </p>
         <h3 id="h3292">
-            <a id=""></a>The Invasion of Phaaze
+            The Invasion of Phaaze
         </h3>
         <figure data-id="18zqgy9h1t7injpg" data-recommend-id="image://18zqgy9h1t7injpg" data-format="jpg" data-width="640" data-height="399" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -187,7 +187,7 @@
         <p> As the Tallon IV seed began its centuries of travelling through space, the lone Metroid within absorbed vast amounts of Phazon and radiation. It became self-aware, and grew in size, intelligence and strength. It used the ruined pieces of Chozo armour to construct itself an exoskeleton, and descended into madness. The exoskeleton failed to protect the creature from the endless radiation, and the Metroid became as exotic as Phaaze’s extinct superpredators: An undying tortured genius. [MP / MP2 / MP3 / MP3 SP] </p>
         <p> The creature that would come to be known as Metroid Prime resented Phaaze for imprisoning it in the Leviathan. It resented the Chozo for creating and discarding the Metroids. It decided that it would survive, bring order to the chaotic universe that birthed it, and somehow enslave Phaaze to its will. In its solitude, immortal as a consequence of its mutations, Metroid Prime plotted its revenge against the universe. [MP / MP2 / MP3 / MP3 SP] </p>
         <h3 id="h3293">
-            <a id=""></a>The Dark Planet
+            The Dark Planet
         </h3>
         <p> With a clear understanding of the danger of living planets, the Chozo authority commenced a search for similar threats. With far more advanced technology than their ancestors had during the Elysian era, the Chozo were unfortunate enough to find a planet of even greater horrors. [MP 3 SP / M2] </p>
         <figure data-id="18zqhnuwesum0jpg" data-recommend-id="image://18zqhnuwesum0jpg" data-format="jpg" data-width="640" data-height="480" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
@@ -240,10 +240,10 @@
         <p> Alpha, Gamma, Zeta and Omega Metroids spawned quickly, and responded to the screams of their Queen. With their bulk and strength, they smashed through the glass laboratory and slaughtered their Chozo creators. The Chozo warriors were hunted down and crushed. [M2] </p>
         <p> SR388 developed into a new cauldron of hostility. The Metroids served as the apex predator, and the robots of the Chozo decayed into machine madness and prowled the ruins, killing on sight. The Chozo mission to suppress the X-Parasite had been a success, but the planet had gained its revenge. [M2 / M2 SP / MF] </p>
         <h2 id="h3294">
-            <a id=""></a>Part Two: The End of the Renaissance
+            Part Two: The End of the Renaissance
         </h2>
         <h3 id="h3295">
-            <a id=""></a>The Holy World
+            The Holy World
         </h3>
         <p> The Chozo had devastated two planets for the good of the universe, and sustained many causalities. The superpredators of Phaaze were extinct and the X-Parasites were permanently suppressed. With the crisis over, the race became consumed with a collective sense of guilt over their necessary actions. The Chozo believed the life of the universe to be sacred, and had to reconcile their aggressive actions with their faith. [MP SP / MP3 SP / M2 / MF] </p>
         <p> Worse still, their prophets continued to have visions of endless conflict and death. War was coming to the universe, and it seemed that their sins had not saved them. Many began to doubt these visions, and a schism occurred. [MP/ MP3 SP] </p>
@@ -275,7 +275,7 @@
         <p> (<span><a data-ga="[[&quot;Embedded Url&quot;,&quot;External link&quot;,&quot;http://havoc-dm.deviantart.com/art/Metroid-Prime-74392852&quot;,{&quot;metric25&quot;:1}]]" href="http://havoc-dm.deviantart.com/art/Metroid-Prime-74392852" target="_blank" rel="noopener noreferrer"><em>Source: Havoc-DM</em></a></span>) </p>
         <p> Within the Impact Crater, Metroid Prime remained trapped within the Chozo energy field. In its armour constructed from ancient Chozo power suits, it continued its wait to be unleashed on the universe. [MP / MP3 SP] </p>
         <h3 id="h3296">
-            <a id=""></a>Dark Echoes
+            Dark Echoes
         </h3>
         <figure data-id="18zqiho9ab5xrjpg" data-recommend-id="image://18zqiho9ab5xrjpg" data-format="jpg" data-width="640" data-height="639" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -340,7 +340,7 @@
         <p> The war was being lost by the Luminoth. The Ing had exterminated most of their race and had stolen too many vital technologies. With the theft of essential energy components from the Light of Aether power network, they had become a defeated people. [MP2] </p>
         <p> The Ing had destroyed all of Aether’s ancient ships, and condemned the Luminoth to no escape from their doomed world. With no other choice, the survivors sealed themselves in an inner sanctum, and entered a state of suspended animation. One custodian, U-Mos, volunteered to be their guardian. As Aether became weaker and weaker, the Luminoth waited for someone to save them. They would wait a very long time. [MP2] </p>
         <h3 id="h3297">
-            <a id=""></a>The Sacrifice of the Alimbics
+            The Sacrifice of the Alimbics
         </h3>
         <figure data-id="18zqitehsufhejpg" data-recommend-id="image://18zqitehsufhejpg" data-format="jpg" data-width="640" data-height="393" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -361,7 +361,7 @@
         <p> The Alimbics performed an act of supreme sacrifice. They combined the mental energies of their entire race to forge a prison for Gorea. The psychic prison held it bound, and it was transplanted into an organic vessel called The Oubliette. The vessel was launched into the void outside of the universe, a course that would keep its indestructible prisoner in exile forever. The systems of the prison ship were tasked to scan the every molecule of the imprisoned Gorea, and devise an Omega weapon that could be used to kill it. [MPH / MPH SP] </p>
         <p> The mental energies expelled in this plan consumed the physical bodies of the entire Alimbic race. They vanished from the universe in an instant. Their sacrifice protected all life in the cosmos from Gorea’s murderous rampage. [MPH] </p>
         <h3 id="h3298">
-            <a id=""></a>The War of Bryyo
+            The War of Bryyo
         </h3>
         <figure data-id="18zqixy9iqkrejpg" data-recommend-id="image://18zqixy9iqkrejpg" data-format="jpg" data-width="640" data-height="414" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -374,7 +374,7 @@
         <p> Over the previous centuries, the scientific agenda had dominated, with space travel proving beneficial and enlightening. As the Chozo, Luminoth and Alimbics faced extinction, the religious Bryyonians believed more than ever that the universe was a hostile place, and became desperate to stop their scientific counterparts. [MP3] </p>
         <p> A great war exploded across Bryyo. By its end, the scholars had been wiped out and the survivors of both sides had regressed to a feral existence. The race devolved into animals, wandering around ruins that they no longer understood. Language vanished and strength ruled. Anyone who landed on Bryyo was meat, to be killed and eaten. [MP3] </p>
         <h3 id="h3299">
-            <a id=""></a>The Little Rainy Planet
+            The Little Rainy Planet
         </h3>
         <p> The onslaught of vengeances, conquerors, poisons and politics destroyed the old races. The Alimbics had lost their flesh, while the Bryyonians had lost their souls. The Luminoth had retreated into stasis, and the Chozo of Tallon IV had been condemned to a living death. [MP / MPH / MP2 / MP3] </p>
         <figure data-id="18zqiznfcy0icjpg" data-recommend-id="image://18zqiznfcy0icjpg" data-format="jpg" data-width="640" data-height="430" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
@@ -403,15 +403,15 @@
         <p> A great hunter, clad in orange, red and green. The Chozo glimpsed a future hero, alone in the darkness beneath worlds, fighting so that good could survive evil. They saw her curing poisoned planets, and ending galactic wars. They saw the universe’s one chance to survive its apocalyptic future. They saw the only one who could defy prophecy. [M1 / MP3 SP] </p>
         <p> And they saw her wearing Chozo armour. [M1] </p>
         <h2 id="h3300">
-            <a id=""></a>Part Three: The New Empires
+            Part Three: The New Empires
         </h2>
         <h3 id="h3301">
-            <a id=""></a>The Humans
+            The Humans
         </h3>
         <p> On the planet Earth, the human race had finally developed a ship capable of leaving their solar system. A brave crew ventured into the universe to learn whether life existed elsewhere. Their discoveries fundamentally changed the human condition. On planet after planet, they found ruined tombs and cities, guarded by weathered statues of dead races. Most significant of all, they found technology. [M1 SP] </p>
         <p> The humans reverse engineered their salvage, and advanced with pace. Within another century, faster-than-light ships explored the stars, and colonies transformed hostile worlds into homes. Peaceful relations formed between other younger races, and a great Galactic Federation was founded. [M1 SP] </p>
         <h3 id="h3302">
-            <a id=""></a>The Space Pirates
+            The Space Pirates
         </h3>
         <p> In a less hospitable region of space, a cabal of battered races joined their forces to survive. On planets where acid rain burned flesh and magma flowed, the alliance expanded into a hardened space empire. They ventured into nearby systems and took what they needed from anyone they could reach. They found the ruins of the old races and ransacked the ancient technologies within. They immersed themselves in science and unlocked the secrets of their finds. Within decades, they had advanced their spread with stronger and faster ships. The creatures enhanced themselves, rewriting their genetics and integrating mechanisms beneath their flesh. They were unique: a cybernetic race of furious murderers with a skill for patient scientific process. As more planets were invaded, their conquered civilisations were conscripted by force. [M1 SP / MP / MP3] </p>
         <p> The inevitable moment came when their Empire reached the borders of the vast Galactic Federation. [M1 SP / MP / MP3] </p>
@@ -424,7 +424,7 @@
         <p> (<span><a data-ga="[[&quot;Embedded Url&quot;,&quot;External link&quot;,&quot;http://mr-corr.deviantart.com/art/fight-for-norion-175087687&quot;,{&quot;metric25&quot;:1}]]" href="http://mr-corr.deviantart.com/art/fight-for-norion-175087687" target="_blank" rel="noopener noreferrer"><em>Artist: Mr-Corr</em></a></span>) </p>
         <p> First contact was brief and furious. On that day, the warning went out to all the worlds of the Federation: Beware the Space Pirates. Though no state of war was officially declared, the empires attacked each other on sight. The Galactic Federation was large enough to repress any meaningful incursions into their space. [M1 SP / MP SP / MP3 SP / SM SP] </p>
         <h3 id="h3303">
-            <a id=""></a>The Massacre of Two Families
+            The Massacre of Two Families
         </h3>
         <p> The Galactic Federation discovered the last Chozo Colony on Zebes. The tired, ancient avians welcomed the humans and shared with them wisdom and knowledge. They offered the Galactic Federation new sciences, and taught them how to make organic computers. The Federation studied the Chozo’s own central processing unit, an engineered brain that mothered over their colony, and left with plans to assemble their own variants. On the nearest habitable planet of K-2L, a colony was established. [M1 / MP3 SP] </p>
         <p> On this world, the human Samus Aran was born. [M1] </p>
@@ -465,7 +465,7 @@
         <p> The Chozo hid their technologies throughout the planet, in places that they were certain Samus would find them. They concealed a second Power Suit within the walls of their holy temple, having foreseen that Samus may require it in the future. They then returned to the surface to await the inevitable. [M1 SP] </p>
         <p> The Space Pirates invaded in force, and murdered Samus Aran’s second family. The Chozo became extinct. [M1 / MP SP] </p>
         <h3 id="h3304">
-            <a id=""></a>The Mother Brain
+            The Mother Brain
         </h3>
         <p> Space Pirate scientists arrived shortly after the carnage and focused their attention on the legendary Chozo organic central processing unit. They rewrote its benign programming and injected stimulants into its flesh. They enabled it to form an artificial intelligence obsessed with strategy and conquest. They drove its computational potential towards absolute advancement of the Space Pirate Empire. [M1 SP] </p>
         <figure data-id="18zqk2icdbv0cjpg" data-recommend-id="image://18zqk2icdbv0cjpg" data-format="jpg" data-width="640" data-height="528" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
@@ -478,7 +478,7 @@
         <p> The results went beyond High Command’s most optimistic projections. The Space Pirates had created a leader, a desperately needed figure to unite their fragmented empire. They had created their Mother Brain. The great Space Pirate generals Ridley and Kraid arrived at Zebes, ready to pay tribute to their new master and to plan for the future. Mother Brain delivered to the Space Pirates knowledge and power. She told them of a world referenced in her oldest Chozo databanks, a planet bathed in a mutagenic poison waiting to be farmed. She instructed High Command to prepare an armada of ships and invade the planet Tallon IV. [M1 / MP SP] </p>
         <p> The order was followed immediately, and the High Command discovered a world deranged by contagion. Beneath its surface, endless pools of Phazon waited to be weaponised, and a great mining operation began. Mother Brain received data from their readings on the planet; even after thousands of years, the source of the Phazon was still contained in the Chozo force field. She scrutinised her records further, and was unable to ascertain any method of breaching the barrier. The Space Pirates could retrieve the Phazon, but were denied access to its source. [MP] </p>
         <h3 id="h3305">
-            <a id=""></a>The Metroids
+            The Metroids
         </h3>
         <p> A perfect storm brewed. As the Space Pirates gained access to the most potent mutagen in the universe, the Galactic Federation made an equally eventful discovery: They found the dark planet SR388. [M1 / M2] </p>
         <figure data-id="18zqk5mt4ocetjpg" data-recommend-id="image://18zqk5mt4ocetjpg" data-format="jpg" data-width="640" data-height="477" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
@@ -495,7 +495,7 @@
         <p> The Space Pirates overran the Galactic Federation vessel and stole the Metroid creatures. They divided their prize: some were sent to their nearest Homeworld; others were sent to the Tallon IV outpost; and the most potent were delivered straight to Zebes for the experiments of Mother Brain. [M1 / MP / MP3] </p>
         <p> With the arrival of the first Phazon samples from Tallon IV, the exotic substance allowed the Space Pirates to slowly produce stable cloned Metroids across their breeding sites. [M1 SP / MP SP] </p>
         <h3 id="h3306">
-            <a id=""></a>The Revenge of Samus Aran
+            The Revenge of Samus Aran
         </h3>
         <figure data-id="18zqk7ps96cb3jpg" data-recommend-id="image://18zqk7ps96cb3jpg" data-format="jpg" data-width="640" data-height="480" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
             <div contenteditable="false" data-syndicationrights="false">
@@ -547,7 +547,7 @@
         <p> (<span><a data-ga="[[&quot;Embedded Url&quot;,&quot;External link&quot;,&quot;http://imachinivid.deviantart.com/art/Super-missile-309591371&quot;,{&quot;metric25&quot;:1}]]" href="http://imachinivid.deviantart.com/art/Super-missile-309591371" target="_blank" rel="noopener noreferrer"><em>Artist: Imachinivid</em></a></span>) </p>
         <p> With her new armaments, Samus cleansed the Space Pirate presence from Zebes. She came to be known as “The Hunter”, and the Space Pirates learned that they will always be hunted down for what they did to her families. They fled the planet in terror. [M1 / MP / MP2 / MP3] </p>
         <h3 id="h3307">
-            <a id=""></a>Tallon IV
+            Tallon IV
         </h3>
         <p> As years passed, Samus Aran accepted further missions from the Galactic Federation. The bounty earned funded her personal vendetta against the Space Pirates. She improved her armaments, paid for black market information and stormed their outposts. Samus showed her enemies no mercy, and became the feared nemesis of their entire civilisation. With the income from her Federation services, Samus had soon amassed enough money to buy the most secret information regarding the Space Pirates: the coordinates of their stronghold on an old forgotten planet called Tallon IV. [MP1 SP] </p>
         <p> Samus guided her ship into the Tallon system and investigated an orbiting space station. She discovered a failed genetic engineering facility whose Space Pirate crew was murdered when they lost control of their own creations. Samus fought her way through the ferocious beasts scattered within, and discovered a half-insane cyborg recreation of the Space Pirate general Ridley. As the station began to collapse, the biomechanical dragon fled to the world below, and Samus pursued. [MP1] </p>
@@ -586,7 +586,7 @@
         <p> Samus’ final discovery was the most horrific. The powerful, poisonous Phazon was not a rare material on Tallon IV. Despite the Chozo shield containing the Impact Crater, the substance had spread and consumed the world inside-out. The core of the planet presented the Space Pirates with a vast supply of Phazon, enough to fuel their conquest of the stars. [MP1] </p>
         <p> Samus destroyed the mining facilities and laboratories, and reconstructed the twelve parts of the ancient Chozo cipher. She destroyed living weapons such as the Thardus experiment, and annihilated the prototype Omega Pirate. She overcame corrupted Metroids, and banished the tormented Chozo ghosts from the living world. She fought the mad Meta Ridley, and on his demise deactivated the Chozo containment shield. As prophesised, Samus Aran entered the Impact Crater. [MP1] </p>
         <h3 id="h3308">
-            <a id=""></a>The Worm
+            The Worm
         </h3>
         <p> Samus Aran had opened Metroid Prime’s cage, and had no understanding of what she was about to unleash on the universe. The creature had been imprisoned in a different era, and had spent eons being tortuously transformed by Phazon into an undying mad genius. [MP1] </p>
         <figure data-id="18zqkn672gklqjpg" data-recommend-id="image://18zqkn672gklqjpg" data-format="jpg" data-width="640" data-height="499" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">
@@ -607,7 +607,7 @@
         <p> Seemingly dying, Metroid Prime lashed out, grabbing a layer of material from Samus Aran’s armour. The creature melted into a pool of Phazon particles, and the bounty hunter evacuated the Impact Crater. [MP1] </p>
         <p> Samus Aran had seemingly succeeded in her mission. The surviving Space Pirates abandoned their devastated facilities and hastily evacuated the planet. With the defeat of Metroid Prime, the Phazon contagion was slowly stopping its spread. The tormented Chozo spirits that had been bound to the planet were finally able to achieve their rest. Leaving the world to recover from its devastation, Samus Aran headed back to the stars. [MP1 / MP1 SP] </p>
         <h3 id="h3309">
-            <a id=""></a>The Dark Hunter
+            The Dark Hunter
         </h3>
         <p> Metroid Prime’s exposure to millennia of Phazon had given the creature extremely exotic abilities, the most potent being its durability – to recreate itself after nearly any level of destruction. As it had collapsed on itself, the essence of Metroid Prime craved the strength and adaptability present in Samus Aran. In the Talon IV impact crater, Metroid Prime recreated itself as a dark copy of the woman who had defeated it. [MP 1 / MP2 / MP3 SP] </p>
         <figure data-id="18zqkq6pqyr8ljpg" data-recommend-id="image://18zqkq6pqyr8ljpg" data-format="jpg" data-width="640" data-height="412" data-lightbox="true" data-recommended="false" contenteditable="false" draggable="false">

--- a/test-pages/readability/wapo-2/expected.html
+++ b/test-pages/readability/wapo-2/expected.html
@@ -1,8 +1,10 @@
 <div id="readability-page-1" class="page">
-    <p><a name="1c164a7079bfe20ebd611d79f96418b5a225cbc6"></a>
-        <img src="https://img.washingtonpost.com/rf/image_400w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" data-hi-res-src="https://img.washingtonpost.com/rf/image_1484w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" data-low-res-src="https://img.washingtonpost.com/rf/image_400w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" />
-        <br /> <span>Israeli Prime Minister Benjamin Netanyahu reacts as he visits the Western Wall in Jerusalem on March 18 following his party's victory in Israel's general election. (Thomas Coex/AFP/Getty Images)</span>
-    </p>
+    <div>
+        <p>
+            <img src="https://img.washingtonpost.com/rf/image_400w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" data-hi-res-src="https://img.washingtonpost.com/rf/image_1484w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" data-low-res-src="https://img.washingtonpost.com/rf/image_400w/2010-2019/WashingtonPost/2015/03/18/National-Economy/Images/Nic6429750-1140.jpg?uuid=zLIZQs2KEeSip5UXo6cFBg" />
+            <br /> <span>Israeli Prime Minister Benjamin Netanyahu reacts as he visits the Western Wall in Jerusalem on March 18 following his party's victory in Israel's general election. (Thomas Coex/AFP/Getty Images)</span>
+        </p>
+    </div>
     <article>
         <p>President Obama told the U.N. General Assembly 18 months ago that he would seek “real breakthroughs on these two issues — Iran’s nuclear program and ­Israeli-Palestinian peace.”</p>
         <p>But <a href="http://www.washingtonpost.com/world/netanyahu-sweeps-to-victory-in-israeli-election/2015/03/18/af4e50ca-ccf2-11e4-8730-4f473416e759_story.html" title="www.washingtonpost.com">Benjamin Netanyahu’s triumph</a> in Tuesday’s parliamentary elections keeps in place an Israeli prime minister who has declared his intention to resist Obama on both of these fronts, guaranteeing two more years of difficult diplomacy between leaders who barely conceal their personal distaste for each other.</p>

--- a/test-pages/readability/yahoo-3/expected.html
+++ b/test-pages/readability/yahoo-3/expected.html
@@ -19,7 +19,7 @@
             <p>On one Facebook page an unidentified poster put up her picture writing and wrote they found it was “disrespectful, rude, tacky, disgusting, and against the U.S. Flag Code.”</p>
             <p><span id="schemaorg">
                     <div>
-                        <figure data-orig-index="2"> <a name="cover-c9b69c1a26e19ae9fe744763dc31e9ac" id="cover-c9b69c1a26e19ae9fe744763dc31e9ac" data-rapid_p="17"></a>
+                        <figure data-orig-index="2">
                             <div>
                                 <p>View photo</p>
                                 <p><span>.</span></p>


### PR DESCRIPTION
- Link elements (`<a>`) without an `href` attribute and without child nodes are now removed from the article content during post-processing.
- Changed how phrasing content determines wrapping some `<div>` element children with a `<p>` element. Now the element must contain some nodes to be wrapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced content processing by removing empty, non-functional links and refining text-wrapping for improved article presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->