### PR TITLE
fix `get_row_and_col_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Previously, it incorrectly attempted to retrieve the `rowspan` attribute from the `table` element.
+
 ## [0.8.0] - 2025-03-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Previously, it incorrectly attempted to retrieve the `rowspan` attribute from the `table` element.
+- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Skipped counting `rowspan` since it is meaningless..
 
 ## [0.8.0] - 2025-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Skipped counting `rowspan` since it is meaningless..
+- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Skipped counting `rowspan` since it is meaningless.
 
 ## [0.8.0] - 2025-03-10
 

--- a/src/prep_article.rs
+++ b/src/prep_article.rs
@@ -222,13 +222,14 @@ fn get_row_and_col_count(table: &Selection) -> (usize, usize) {
     let mut rows = 0usize;
     let mut cols = 0usize;
     for tr in table.select("tr").iter() {
-        let rowspan = tr.attr_or("rowspan", "1");
-        rows += rowspan.parse::<usize>().unwrap_or(1);
+        // No need to adjust row count by the `row span` at all
+        rows += 1;
 
         //Now look for column-related info
         let mut columns_in_this_row = 0;
 
         for cell in tr.select("td").iter() {
+            // TODO: this also may take no sense
             let colspan = cell.attr_or("colspan", "1");
             columns_in_this_row += colspan.parse::<usize>().unwrap_or(1);
         }

--- a/src/prep_article.rs
+++ b/src/prep_article.rs
@@ -222,7 +222,7 @@ fn get_row_and_col_count(table: &Selection) -> (usize, usize) {
     let mut rows = 0usize;
     let mut cols = 0usize;
     for tr in table.select("tr").iter() {
-        let rowspan = table.attr_or("rowspan", "1");
+        let rowspan = tr.attr_or("rowspan", "1");
         rows += rowspan.parse::<usize>().unwrap_or(1);
 
         //Now look for column-related info


### PR DESCRIPTION
- Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Skipped counting `rowspan` since it is meaningless.
