### PR TITLE
skip svg  elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ### Fixed
 - Fixed the `get_row_and_col_count` function, which determines the number of rows and columns. Skipped counting `rowspan` since it is meaningless.
 
+### Changed
+- Ignoring `svg` elements during pre-filtering and element collection for scoring, improving performance for documents with many `svg` elements.
+
 ## [0.8.0] - 2025-03-10
 
 ### Changed

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -170,6 +170,11 @@ fn pre_filter_document(doc: &Document, metadata: &mut Metadata) {
             continue;
         }
 
+        if node.has_name("svg") {
+            next_node_id = get_child_or_sibling_id(&node, true);
+            continue;
+        }
+
         if MATCHER_DIALOGS.match_element(&node) {
             next_node_id = get_child_or_sibling_id(&node, true);
             node.remove_from_parent();
@@ -649,6 +654,11 @@ fn collect_elements_to_score<'a>(root_node: &'a NodeRef, strip_unlikely: bool) -
     let mut next_node_id = get_child_or_sibling_id(root_node, false);
     while let Some(node_id) = next_node_id {
         let mut node = NodeRef::new(node_id, tree);
+
+        if node.has_name("svg") {
+            next_node_id = get_child_or_sibling_id(&node, true);
+            continue;
+        }
 
         if strip_unlikely {
             if is_unlikely_candidate(&node) {


### PR DESCRIPTION
- Ignoring `svg` elements during pre-filtering and element collection for scoring, improving performance for documents with many `svg` elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Optimized document processing by bypassing certain complex visual elements during analysis. This enhancement reduces unnecessary computational overhead, resulting in faster and more efficient handling of content-rich documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->