### PR TITLE
add `Config::min_score_to_adjust`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added the `Config::min_score_to_adjust` option, which allows controlling the minimum score required for adjustment during the scoring process. Only nodes with a score higher than this value will be adjusted by their link density. The higher the value, the faster the scoring process. Thus, the higher the value, the faster the scoring process.
+
 ### Changed
 - Improved the internal function `fix_lazy_images` to better detect occurrences of `lazy` as a substring within an element's `class` attribute.
 - Optimized the internal function `should_clean_conditionally` to improve performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added the `Config::min_score_to_adjust` option, which allows controlling the minimum score required for adjustment during the scoring process. Only nodes with a score higher than this value will be adjusted by their link density. The higher the value, the faster the scoring process. Thus, the higher the value, the faster the scoring process.
+- Added the `Config::min_score_to_adjust` option, which allows controlling the minimum score required for adjustment during the scoring process. Only nodes with a score higher than this value will be adjusted by their link density. Thus, the higher the value, the faster the scoring process.
 
 ### Changed
 - Improved the internal function `fix_lazy_images` to better detect occurrences of `lazy` as a substring within an element's `class` attribute.

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::hint::black_box;
 
-use dom_smoothie::{Article, Readability, ReadabilityError};
+use dom_smoothie::{Article, Config, Readability, ReadabilityError};
 
-fn dom_smoothie_parse(contents: &str) -> Result<Article, ReadabilityError> {
-    let mut readability = Readability::new(contents, None, None)?;
+fn dom_smoothie_parse(contents: &str, cfg: &Config) -> Result<Article, ReadabilityError> {
+    let mut readability = Readability::new(contents, None, Some(cfg.clone()))?;
     readability.parse()
 }
 
@@ -25,8 +25,12 @@ fn bench_dom_smoothie_parse(c: &mut Criterion) {
     ];
 
     for (name, contents) in test_cases {
+        let cfg = Config {
+            min_score_to_adjust: 10.0,
+            ..Default::default()
+        };
         group.bench_with_input(BenchmarkId::new("parse", name), contents, |b, contents| {
-            b.iter(|| dom_smoothie_parse(black_box(contents)))
+            b.iter(|| dom_smoothie_parse(black_box(contents), black_box(&cfg)))
         });
     }
     group.finish();

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -11,22 +11,23 @@ fn dom_smoothie_parse(contents: &str, cfg: &Config) -> Result<Article, Readabili
 fn bench_dom_smoothie_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("dom_smoothie");
 
+    let small = include_str!("../test-pages/ok/ehow-1/source.html");
+    let medium = include_str!("../test-pages/ok/engadget/source.html");
+    let large = include_str!("../test-pages/ok/wikipedia-2/source.html");
+
     // Test different sizes/types of content
     let test_cases = vec![
-        ("small", include_str!("../test-pages/ok/ehow-1/source.html")),
-        (
-            "medium",
-            include_str!("../test-pages/ok/engadget/source.html"),
-        ),
-        (
-            "large",
-            include_str!("../test-pages/ok/wikipedia-2/source.html"),
-        ),
+        ("small", small, 5.0f32),
+        ("medium", medium, 5.0f32),
+        ("large", large, 5.0f32),
+        ("small, min score to adjust 10", small, 10.0f32),
+        ("medium, min score to adjust 10", medium, 10.0f32),
+        ("large, min score to adjust 10", large, 10.0f32),
     ];
 
-    for (name, contents) in test_cases {
+    for (name, contents, min_score_to_adjust) in test_cases {
         let cfg = Config {
-            min_score_to_adjust: 10.0,
+            min_score_to_adjust,
             ..Default::default()
         };
         group.bench_with_input(BenchmarkId::new("parse", name), contents, |b, contents| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use crate::{
 
 pub(crate) static DEFAULT_N_TOP_CANDIDATES: usize = 5;
 pub(crate) static DEFAULT_CHAR_THRESHOLD: usize = 500;
+pub(crate) static DEFAULT_MIN_SCORE_TO_ADJUST: f32 = 5.0;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, Copy)]
@@ -42,6 +43,10 @@ pub struct Config {
     pub n_top_candidates: usize,
     /// Character threshold for content extraction
     pub char_threshold: usize,
+    /// The minimum score required for a node to be adjusted during scoring. Defaults to 5.0.  
+    /// The higher this value, the faster the node scoring process, as link density calculations are performed less frequently.  
+    /// A value between 5 and 10 is usually enough to yield good results.
+    pub min_score_to_adjust: f32,
     /// The minimum score required for the document to be considered readable. Defaults to 20.0.
     /// Used only for [`crate::Readability::is_probably_readable`].
     pub readable_min_score: f32,
@@ -65,6 +70,7 @@ impl Default for Config {
             disable_json_ld: false,
             n_top_candidates: DEFAULT_N_TOP_CANDIDATES,
             char_threshold: DEFAULT_CHAR_THRESHOLD,
+            min_score_to_adjust: DEFAULT_MIN_SCORE_TO_ADJUST,
             readable_min_score: MIN_SCORE,
             readable_min_content_length: MIN_CONTENT_LENGTH,
             candidate_select_mode: CandidateSelectMode::Readability,


### PR DESCRIPTION
- Added the `Config::min_score_to_adjust` option, which allows controlling the minimum score required for adjustment during the scoring process. Only nodes with a score higher than this value will be adjusted by their link density. Thus, the higher the value, the faster the scoring process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that lets users set a minimum score threshold for content adjustments, potentially speeding up extraction when higher values are used.

- **Refactor**
  - Enhanced the underlying parsing and candidate selection process for improved efficiency and flexibility in content extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->