### PR TITLE
Find `image` entries in `head` block when parsing metadata

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -170,7 +170,7 @@ pub(crate) static META_PROPERTY_PREFIXES: &[&str] = &["article", "dc", "dcterm",
 
 #[rustfmt::skip]
 pub(crate) static META_PROPERTY_KEYS: &[&str] = &[
-    "author", "creator", "description", "published_time", "title", "site_name",
+    "author", "creator", "description", "published_time", "title", "site_name", "image"
 ];
 
 #[rustfmt::skip]

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -1265,6 +1265,29 @@ mod tests {
     }
 
     #[test]
+    fn test_get_article_metadata_without_json_ld() {
+        let contents = include_str!("../test-pages/rustwiki_2024.html");
+        let config = Config {
+            disable_json_ld: true,
+            ..Default::default()
+        };
+        let ra = Readability::new(contents, None, Some(config)).unwrap();
+        let metadata = ra.get_article_metadata(None);
+
+        assert_eq!("Rust (programming language) - Wikipedia", metadata.title);
+        assert!(metadata.byline.is_none());
+        assert!(metadata.excerpt.is_none());
+        assert!(metadata.site_name.is_none());
+        assert!(metadata.published_time.is_none());
+        assert!(metadata.modified_time.is_none());
+        assert!(metadata.image.is_some());
+        assert!(metadata.favicon.is_none());
+        assert_eq!(Some("en".to_string()), metadata.lang);
+        assert!(metadata.url.is_none());
+        assert!(metadata.dir.is_none());
+    }
+
+    #[test]
     fn test_base_uri() {
         let contents = r#"<!DOCTYPE>
         <html>


### PR DESCRIPTION
The extract method `get_article_metadata` in `Readability` parses a list of metadata fields. The first part of the method analyzes the list of accepted `<meta>` tags, for example OpenGraph, Twitter card etc.

Unfortunately this part also skips a number of valid tags, when filtering against the list of valid tags to read, in particular it filters according to the [`META_PROPERTY_KEYS`](https://github.com/justahero/dom_smoothie/blob/main/src/glob.rs#L172) string array. The subsequent checks to find certain metadata fields in this set will not be found. Among the fields that are skipped for example are the `image` tags, e.g. `og:image`, `twitter:image`. This means the current parser does not return any images from the `<head>` block, for example when disabling `ld+json`.

This change adds the `image` entry to allow the `get_article_metadata` to find image URLs in the `head` block of the HTML.

P.S. Thanks for this library, it's really good in extracting text from HTML for later use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing "image" as a meta property key.
* **Tests**
  * Introduced a new unit test to verify metadata extraction behavior when JSON-LD is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->