### PR TITLE
fix MATCHER_SOURCES; cargo fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ### Fixed
 - Fixed `Readability::fix_relative_uris` behavior when handling srcset\'s item without a condition (e.g., `image.jpg` instead of `image.jpg 2x`).
+- Fixed `MATCHER_SOURCES`, which previously contained a typo (`sources` instead of `source`).
 
 ## [0.11.2] - 2024-08-09
 

--- a/dom-smoothie-bench/benches/parse.rs
+++ b/dom-smoothie-bench/benches/parse.rs
@@ -32,7 +32,8 @@ fn bench_dom_smoothie_parse(c: &mut Criterion) {
         };
         group.bench_with_input(BenchmarkId::new("parse", name), contents, |b, contents| {
             b.iter(|| {
-                let res = dom_smoothie_parse(black_box(contents), black_box(&cfg)).expect("Parsing failed");
+                let res = dom_smoothie_parse(black_box(contents), black_box(&cfg))
+                    .expect("Parsing failed");
                 black_box(res)
             })
         });

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -44,7 +44,7 @@ pub(crate) static MATCHER_DIALOGS: Lazy<Matcher> =
 pub(crate) static MATCHER_BYLINE: Lazy<Matcher> =
     lazy_matcher!(r#"[rel="author"],[itemprop*="author"]"#);
 pub(crate) static MATCHER_SOURCES: Lazy<Matcher> =
-    lazy_matcher!("img,picture,figure,video,audio,sources");
+    lazy_matcher!("img,picture,figure,video,audio,source");
 pub(crate) static MATCHER_P: Lazy<Matcher> = lazy_matcher!("p");
 pub(crate) static MATCHER_EMBEDS: Lazy<Matcher> = lazy_matcher!("object,embed,iframe");
 pub(crate) static MATCHER_CLEAN: Lazy<Matcher> =

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -1339,16 +1339,28 @@ mod tests {
 
     #[test]
     fn test_fix_relative_uris_srcset_without_descriptor() {
-        let contents = r#"<!DOCTYPE html>
-        <html><head><base href="https://example.com/"></head>
-        <body><img src="/img/a.jpg" srcset="img/a.jpg, img/b.jpg 2x"></body></html>"#;
+        let contents = r#"
+        <!DOCTYPE html>
+        <html> 
+            <head><base href="https://example.com/"></head>
+            <body>
+                 <video width="320" height="240" controls>
+                    <source src="clip.mp4" type="video/mp4">
+                    Your browser does not support the video tag.
+                </video> 
+                <img src="/img/a.jpg" srcset="img/a.jpg, img/b.jpg 2x">
+            </body>
+        </html>"#;
         let ra = Readability::new(contents, None, None).unwrap();
         let body = ra.doc.select("body");
+
         ra.fix_relative_uris(&body);
-        let got = ra.doc.select("img").attr("srcset").unwrap();
+        let got_img = ra.doc.select("img").attr("srcset").unwrap();
         assert_eq!(
-            got,
+            got_img,
             "https://example.com/img/a.jpg, https://example.com/img/b.jpg 2x".into()
         );
+        let got_video = ra.doc.select("video source").attr("src").unwrap();
+        assert_eq!(got_video, "https://example.com/clip.mp4".into());
     }
 }

--- a/tests/parse_policy.rs
+++ b/tests/parse_policy.rs
@@ -1,8 +1,8 @@
 use dom_smoothie::{ParsePolicy, Readability};
 
+use std::collections::hash_map::DefaultHasher;
 use std::error::Error;
 use std::hash::{Hash, Hasher};
-use std::collections::hash_map::DefaultHasher;
 
 fn hash_text<T: Hash>(text: &T) -> u64 {
     let mut hasher = DefaultHasher::new();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fixed media element matching to correctly handle source tags, improving embedded media parsing and URI handling.

- Documentation
  - Changelog updated to reflect the fix.

- Tests
  - Expanded tests to cover video source URI rewriting; minor import reordering with no behavior change.

- Style
  - Benchmark formatting adjusted; no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->