### PR TITLE
src/glob.rs: replace `MINI_LAZY` with `MATCHER_LAZY_IMG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `MATCHER_LAZY_IMG` is now used in `prep_article::fix_lazy_images` instead of `MINI_LAZY`, since the latter does not support complex selectors.
+
 ## [0.12.0] - 2024-09-04
 
 ### Changed

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -57,6 +57,7 @@ pub(crate) static MATCHER_DATA_TABLE: Lazy<Matcher> =
 pub(crate) static MATCHER_TABLE: Lazy<Matcher> = lazy_matcher!("table");
 pub(crate) static MATCHER_TABLE_MEMBERS: Lazy<Matcher> =
     lazy_matcher!("caption,col,colgroup,tfoot,thead,th");
+pub(crate) static MATCHER_LAZY_IMG: Lazy<Matcher> = lazy_matcher!(r#"[class*="lazy"],img[loading="lazy"]"#);
 
 // --- Mini matchers ---
 
@@ -68,8 +69,7 @@ pub(crate) static MINI_PRESENTATION: Lazy<MiniSelector> =
     Lazy::new(|| MiniSelector::new(r#"[role="presentation"]"#).unwrap());
 pub(crate) static MINI_AINT_DATA_TABLE: Lazy<MiniSelector> =
     Lazy::new(|| MiniSelector::new(r#"[datatable="0"]"#).unwrap());
-pub(crate) static MINI_LAZY: Lazy<MiniSelector> =
-    Lazy::new(|| MiniSelector::new(r#"[class*="lazy"],img[loading="lazy"]"#).unwrap());
+
 
 pub(crate) static TEXTISH_TAGS: &str = "blockquote,dl,div,img,ol,p,pre,table,ul,span,li,td";
 

--- a/src/prep_article.rs
+++ b/src/prep_article.rs
@@ -302,7 +302,8 @@ fn fix_lazy_images(sel: &Selection) {
             }
         }
 
-        if (node.has_attr("src") || node.has_attr("srcset")) && !MINI_LAZY.match_node(node) {
+        if (node.has_attr("src") || node.has_attr("srcset")) && !node.is_match(&MATCHER_LAZY_IMG) {
+            // TODO: Looks like it has no effect
             continue;
         }
 


### PR DESCRIPTION
- `MATCHER_LAZY_IMG` is now used in `prep_article::fix_lazy_images` instead of `MINI_LAZY`, since the latter does not support complex selectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of lazy-loaded images, ensuring images using complex lazy-loading selectors are correctly detected and processed during article preparation. This results in more reliable image loading and display.

- Documentation
  - Updated the changelog (Unreleased) to document the lazy-image handling fix.

- Notes
  - No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->