### PR TITLE
chore: update dom_query to 0.23.0; update test data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- Updated `dom_query` version from `0.22.0` to `0.23.0`.
+
 
 ### Fixed
 - `MATCHER_LAZY_IMG` is now used in `prep_article::fix_lazy_images` instead of `MINI_LAZY`, since the latter does not support complex selectors.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129db2e410aad83e311601f5d0089988c51a926d9914248c7303fd1e63570d52"
+checksum = "a19e6b9e290ede7a2bf896564c4a48408d7a3270316ca9e1e98ae37e74d37b06"
 dependencies = [
  "bit-set",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 exclude = [".*", "test-pages"]
 
 [dependencies]
-dom_query = {version = "0.22.0", features = ["mini_selector", "markdown"]}
+dom_query = {version = "0.23.0", features = ["mini_selector", "markdown"]}
 tendril = {version = "0.4.3"}
 once_cell = { version = "1" }
 serde = {version = "1.0", features = ["derive"], optional = true}

--- a/test-pages/alt/hacker-news/expected.md
+++ b/test-pages/alt/hacker-news/expected.md
@@ -1,91 +1,92 @@
-1\.[Steam Brick: No screen, no controller, just a power button and a USB port](https://crastinator-pro.github.io/steam-brick/) \([crastinator-pro\.github\.io](from?site=crastinator-pro.github.io)\)
-568 points by [sbarre](user?id=sbarre) [14 hours ago](item?id=42825441) \| [hide](hide?id=42825441&goto=news) \| [167 comments](item?id=42825441)
-
-2\.[DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via RL](https://arxiv.org/abs/2501.12948) \([arxiv\.org](from?site=arxiv.org)\)
-823 points by [gradus\_ad](user?id=gradus_ad) [17 hours ago](item?id=42823568) \| [hide](hide?id=42823568&goto=news) \| [694 comments](item?id=42823568)
-
-3\.[YC Graveyard: 821 inactive Y Combinator startups](https://ycgraveyard.iamwillwang.com/) \([iamwillwang\.com](from?site=iamwillwang.com)\)
-139 points by [memalign](user?id=memalign) [5 hours ago](item?id=42828198) \| [hide](hide?id=42828198&goto=news) \| [76 comments](item?id=42828198)
-
-4\.[When AI Promises Speed but Delivers Debugging Hell](https://nsavage.substack.com/p/when-ai-promises-speed-but-delivers) \([nsavage\.substack\.com](from?site=nsavage.substack.com)\)
-5 points by [nsavage](user?id=nsavage) [50 minutes ago](item?id=42829466) \| [hide](hide?id=42829466&goto=news) \| [discuss](item?id=42829466)
-
-5\.[OpenRA – Classic strategy games rebuilt for the modern era](https://www.openra.net/) \([openra\.net](from?site=openra.net)\)
-433 points by [tosh](user?id=tosh) [17 hours ago](item?id=42823667) \| [hide](hide?id=42823667&goto=news) \| [72 comments](item?id=42823667)
-
-6\.[The South Vietnamese pilot who landed a Cessna on a carrier to save his family \(2019\)](https://www.historynet.com/maj-buang-lys-daring-feat-to-save-his-family/) \([historynet\.com](from?site=historynet.com)\)
-227 points by [stmw](user?id=stmw) [11 hours ago](item?id=42826536) \| [hide](hide?id=42826536&goto=news) \| [89 comments](item?id=42826536)
-
-7\.[Emerging Reasoning with Reinforcement Learning](https://hkust-nlp.notion.site/simplerl-reason) \([hkust-nlp\.notion\.site](from?site=hkust-nlp.notion.site)\)
-164 points by [pella](user?id=pella) [9 hours ago](item?id=42827399) \| [hide](hide?id=42827399&goto=news) \| [130 comments](item?id=42827399)
-
-8\.[The Simplicity of Prolog](https://bitsandtheorems.com/the-simplicity-of-prolog/) \([bitsandtheorems\.com](from?site=bitsandtheorems.com)\)
-73 points by [thunderbong](user?id=thunderbong) [9 hours ago](item?id=42827335) \| [hide](hide?id=42827335&goto=news) \| [19 comments](item?id=42827335)
-
-9\.[An invalid 68030 instruction accidentally allowed the Mac Classic II to boot](https://www.downtowndougbrown.com/2025/01/the-invalid-68030-instruction-that-accidentally-allowed-the-mac-classic-ii-to-successfully-boot-up/) \([downtowndougbrown\.com](from?site=downtowndougbrown.com)\)
-232 points by [todsacerdoti](user?id=todsacerdoti) [15 hours ago](item?id=42824562) \| [hide](hide?id=42824562&goto=news) \| [42 comments](item?id=42824562)
-
-10\.[Every HTML Element](https://iamwillwang.com/dollar/every-html-element/) \([iamwillwang\.com](from?site=iamwillwang.com)\)
-326 points by [wxw](user?id=wxw) [17 hours ago](item?id=42823722) \| [hide](hide?id=42823722&goto=news) \| [100 comments](item?id=42823722)
-
-11\.[I ask this chess puzzle to every new LLM](https://gist.github.com/abhishek-anand/a65ff0e44d158ae306dcce9151b1331c) \([gist\.github\.com](from?site=gist.github.com)\)
-17 points by [thepoet](user?id=thepoet) [4 hours ago](item?id=42795488) \| [hide](hide?id=42795488&goto=news) \| [19 comments](item?id=42795488)
-
-12\.[SQLook – A free online SQLite database manager with a Windows 2000 interface](https://sqlook.com) \([sqlook\.com](from?site=sqlook.com)\)
-124 points by [gringow](user?id=gringow) [12 hours ago](item?id=42826171) \| [hide](hide?id=42826171&goto=news) \| [36 comments](item?id=42826171)
-
-13\.[Apache Iceberg](https://iceberg.apache.org/) \([apache\.org](from?site=apache.org)\)
-105 points by [jacobmarble](user?id=jacobmarble) [12 hours ago](item?id=42799388) \| [hide](hide?id=42799388&goto=news) \| [34 comments](item?id=42799388)
-
-14\.[Explainer: What's R1 and Everything Else?](https://timkellogg.me/blog/2025/01/25/r1) \([timkellogg\.me](from?site=timkellogg.me)\)
-62 points by [Philpax](user?id=Philpax) [8 hours ago](item?id=42827601) \| [hide](hide?id=42827601&goto=news) \| [9 comments](item?id=42827601)
-
-15\.[The Graphics Codex](https://graphicscodex.com/) \([graphicscodex\.com](from?site=graphicscodex.com)\)
-25 points by [board](user?id=board) [6 hours ago](item?id=42827976) \| [hide](hide?id=42827976&goto=news) \| [3 comments](item?id=42827976)
-
-16\.[The Hunt for Error -22](https://tweedegolf.nl/en/blog/145/the-hunt-for-error--22) \([tweedegolf\.nl](from?site=tweedegolf.nl)\)
-10 points by [mpalme](user?id=mpalme) [3 hours ago](item?id=42791874) \| [hide](hide?id=42791874&goto=news) \| [4 comments](item?id=42791874)
-
-17\. ![](s.gif) [SigNoz \(YC W21\) Is hiring back end engineers to build open-source Datadog](https://www.linkedin.com/posts/pranay01_inviting-backend-engineers-interested-activity-7275015683980075008-CzV9) \([linkedin\.com](from?site=linkedin.com)\)
-[5 hours ago](item?id=42828294) \| [hide](hide?id=42828294&goto=news)
-
-18\.[Bacteria in Polymers Form Cables That Grow into Living Gels](https://www.caltech.edu/about/news/bacteria-in-polymers-form-cables-that-grow-into-living-gels) \([caltech\.edu](from?site=caltech.edu)\)
-38 points by [gmays](user?id=gmays) [8 hours ago](item?id=42805777) \| [hide](hide?id=42805777&goto=news) \| [2 comments](item?id=42805777)
-
-19\.[Searching for DeepSeek's glitch tokens](https://outsidetext.substack.com/p/anomalous-tokens-in-deepseek-v3-and) \([outsidetext\.substack\.com](from?site=outsidetext.substack.com)\)
-148 points by [arithmoquine](user?id=arithmoquine) [16 hours ago](item?id=42824473) \| [hide](hide?id=42824473&goto=news) \| [39 comments](item?id=42824473)
-
-20\.[An experiment of adding recommendation engine to your app using pgvector search](https://silk.us/blog/vector-search-ai-integration/) \([silk\.us](from?site=silk.us)\)
-44 points by [tanelpoder](user?id=tanelpoder) [11 hours ago](item?id=42804406) \| [hide](hide?id=42804406&goto=news) \| [3 comments](item?id=42804406)
-
-21\.[Wikenigma – an Encyclopedia of Unknowns](https://wikenigma.org.uk/start) \([wikenigma\.org\.uk](from?site=wikenigma.org.uk)\)
-134 points by [jgamman](user?id=jgamman) [15 hours ago](item?id=42824617) \| [hide](hide?id=42824617&goto=news) \| [35 comments](item?id=42824617)
-
-22\.[You probably don't need query builders](https://mattrighetti.com/2025/01/20/you-dont-need-sql-builders) \([mattrighetti\.com](from?site=mattrighetti.com)\)
-111 points by [mattrighetti](user?id=mattrighetti) [17 hours ago](item?id=42778151) \| [hide](hide?id=42778151&goto=news) \| [102 comments](item?id=42778151)
-
-23\.[Open Heart Protocol](https://openheart.fyi/) \([openheart\.fyi](from?site=openheart.fyi)\)
-199 points by [thunderbong](user?id=thunderbong) [21 hours ago](item?id=42791378) \| [hide](hide?id=42791378&goto=news) \| [84 comments](item?id=42791378)
-
-24\.[Using AI to develop a fuller model of the human brain](https://magazine.ucsf.edu/building-a-silicon-brain) \([ucsf\.edu](from?site=ucsf.edu)\)
-72 points by [geox](user?id=geox) [15 hours ago](item?id=42824625) \| [hide](hide?id=42824625&goto=news) \| [27 comments](item?id=42824625)
-
-25\.[Mastering Atari Games with Natural Intelligence](https://www.verses.ai/blog/mastering-atari-games-with-natural-intelligence) \([verses\.ai](from?site=verses.ai)\)
-19 points by [alex\_c](user?id=alex_c) [7 hours ago](item?id=42806998) \| [hide](hide?id=42806998&goto=news) \| [7 comments](item?id=42806998)
-
-26\.[How far can you get in 40 minutes from each subway station in NYC?](https://subwaysheds.com/#11.27/40.7427/-73.9869) \([subwaysheds\.com](from?site=subwaysheds.com)\)
-277 points by [jxmorris12](user?id=jxmorris12) [1 day ago](item?id=42810293) \| [hide](hide?id=42810293&goto=news) \| [168 comments](item?id=42810293)
-
-27\.[Ask HN: How to automate collecting HAR file while user is browsing](item?id=42817554)
-11 points by [royalghost](user?id=royalghost) [4 hours ago](item?id=42817554) \| [hide](hide?id=42817554&goto=news) \| [9 comments](item?id=42817554)
-
-28\.[A FPGA friendly 32 bit RISC-V CPU implementation](https://github.com/SpinalHDL/VexRiscv) \([github\.com/spinalhdl](from?site=github.com/spinalhdl)\)
-105 points by [\_benj](user?id=_benj) [20 hours ago](item?id=42793580) \| [hide](hide?id=42793580&goto=news) \| [48 comments](item?id=42793580)
-
-29\.[Using Linear Programming to find optimal builds in League of Legend](https://versary.town/blog/using-linear-programming-to-find-optimal-builds-in-league-of-legends/) \([versary\.town](from?site=versary.town)\)
-20 points by [birdculture](user?id=birdculture) [6 hours ago](item?id=42796292) \| [hide](hide?id=42796292&goto=news) \| [7 comments](item?id=42796292)
-
-30\.[Immutability Changes Everything \(2016\) \[pdf\]](https://www.cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf) \([cidrdb\.org](from?site=cidrdb.org)\)
-88 points by [fire\_lake](user?id=fire_lake) [15 hours ago](item?id=42824983) \| [hide](hide?id=42824983&goto=news) \| [29 comments](item?id=42824983)
-
+1\. [Steam Brick: No screen, no controller, just a power button and a USB port](https://crastinator-pro.github.io/steam-brick/) \([crastinator-pro\.github\.io](from?site=crastinator-pro.github.io)\)  
+568 points by [sbarre](user?id=sbarre) [14 hours ago](item?id=42825441) \| [hide](hide?id=42825441&goto=news) \| [167 comments](item?id=42825441)  
+  
+2\. [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via RL](https://arxiv.org/abs/2501.12948) \([arxiv\.org](from?site=arxiv.org)\)  
+823 points by [gradus\_ad](user?id=gradus_ad) [17 hours ago](item?id=42823568) \| [hide](hide?id=42823568&goto=news) \| [694 comments](item?id=42823568)  
+  
+3\. [YC Graveyard: 821 inactive Y Combinator startups](https://ycgraveyard.iamwillwang.com/) \([iamwillwang\.com](from?site=iamwillwang.com)\)  
+139 points by [memalign](user?id=memalign) [5 hours ago](item?id=42828198) \| [hide](hide?id=42828198&goto=news) \| [76 comments](item?id=42828198)  
+  
+4\. [When AI Promises Speed but Delivers Debugging Hell](https://nsavage.substack.com/p/when-ai-promises-speed-but-delivers) \([nsavage\.substack\.com](from?site=nsavage.substack.com)\)  
+5 points by [nsavage](user?id=nsavage) [50 minutes ago](item?id=42829466) \| [hide](hide?id=42829466&goto=news) \| [discuss](item?id=42829466)  
+  
+5\. [OpenRA – Classic strategy games rebuilt for the modern era](https://www.openra.net/) \([openra\.net](from?site=openra.net)\)  
+433 points by [tosh](user?id=tosh) [17 hours ago](item?id=42823667) \| [hide](hide?id=42823667&goto=news) \| [72 comments](item?id=42823667)  
+  
+6\. [The South Vietnamese pilot who landed a Cessna on a carrier to save his family \(2019\)](https://www.historynet.com/maj-buang-lys-daring-feat-to-save-his-family/) \([historynet\.com](from?site=historynet.com)\)  
+227 points by [stmw](user?id=stmw) [11 hours ago](item?id=42826536) \| [hide](hide?id=42826536&goto=news) \| [89 comments](item?id=42826536)  
+  
+7\. [Emerging Reasoning with Reinforcement Learning](https://hkust-nlp.notion.site/simplerl-reason) \([hkust-nlp\.notion\.site](from?site=hkust-nlp.notion.site)\)  
+164 points by [pella](user?id=pella) [9 hours ago](item?id=42827399) \| [hide](hide?id=42827399&goto=news) \| [130 comments](item?id=42827399)  
+  
+8\. [The Simplicity of Prolog](https://bitsandtheorems.com/the-simplicity-of-prolog/) \([bitsandtheorems\.com](from?site=bitsandtheorems.com)\)  
+73 points by [thunderbong](user?id=thunderbong) [9 hours ago](item?id=42827335) \| [hide](hide?id=42827335&goto=news) \| [19 comments](item?id=42827335)  
+  
+9\. [An invalid 68030 instruction accidentally allowed the Mac Classic II to boot](https://www.downtowndougbrown.com/2025/01/the-invalid-68030-instruction-that-accidentally-allowed-the-mac-classic-ii-to-successfully-boot-up/) \([downtowndougbrown\.com](from?site=downtowndougbrown.com)\)  
+232 points by [todsacerdoti](user?id=todsacerdoti) [15 hours ago](item?id=42824562) \| [hide](hide?id=42824562&goto=news) \| [42 comments](item?id=42824562)  
+  
+10\. [Every HTML Element](https://iamwillwang.com/dollar/every-html-element/) \([iamwillwang\.com](from?site=iamwillwang.com)\)  
+326 points by [wxw](user?id=wxw) [17 hours ago](item?id=42823722) \| [hide](hide?id=42823722&goto=news) \| [100 comments](item?id=42823722)  
+  
+11\. [I ask this chess puzzle to every new LLM](https://gist.github.com/abhishek-anand/a65ff0e44d158ae306dcce9151b1331c) \([gist\.github\.com](from?site=gist.github.com)\)  
+17 points by [thepoet](user?id=thepoet) [4 hours ago](item?id=42795488) \| [hide](hide?id=42795488&goto=news) \| [19 comments](item?id=42795488)  
+  
+12\. [SQLook – A free online SQLite database manager with a Windows 2000 interface](https://sqlook.com) \([sqlook\.com](from?site=sqlook.com)\)  
+124 points by [gringow](user?id=gringow) [12 hours ago](item?id=42826171) \| [hide](hide?id=42826171&goto=news) \| [36 comments](item?id=42826171)  
+  
+13\. [Apache Iceberg](https://iceberg.apache.org/) \([apache\.org](from?site=apache.org)\)  
+105 points by [jacobmarble](user?id=jacobmarble) [12 hours ago](item?id=42799388) \| [hide](hide?id=42799388&goto=news) \| [34 comments](item?id=42799388)  
+  
+14\. [Explainer: What's R1 and Everything Else?](https://timkellogg.me/blog/2025/01/25/r1) \([timkellogg\.me](from?site=timkellogg.me)\)  
+62 points by [Philpax](user?id=Philpax) [8 hours ago](item?id=42827601) \| [hide](hide?id=42827601&goto=news) \| [9 comments](item?id=42827601)  
+  
+15\. [The Graphics Codex](https://graphicscodex.com/) \([graphicscodex\.com](from?site=graphicscodex.com)\)  
+25 points by [board](user?id=board) [6 hours ago](item?id=42827976) \| [hide](hide?id=42827976&goto=news) \| [3 comments](item?id=42827976)  
+  
+16\. [The Hunt for Error -22](https://tweedegolf.nl/en/blog/145/the-hunt-for-error--22) \([tweedegolf\.nl](from?site=tweedegolf.nl)\)  
+10 points by [mpalme](user?id=mpalme) [3 hours ago](item?id=42791874) \| [hide](hide?id=42791874&goto=news) \| [4 comments](item?id=42791874)  
+  
+17\. ![](s.gif) [SigNoz \(YC W21\) Is hiring back end engineers to build open-source Datadog](https://www.linkedin.com/posts/pranay01_inviting-backend-engineers-interested-activity-7275015683980075008-CzV9) \([linkedin\.com](from?site=linkedin.com)\)  
+[5 hours ago](item?id=42828294) \| [hide](hide?id=42828294&goto=news)  
+  
+18\. [Bacteria in Polymers Form Cables That Grow into Living Gels](https://www.caltech.edu/about/news/bacteria-in-polymers-form-cables-that-grow-into-living-gels) \([caltech\.edu](from?site=caltech.edu)\)  
+38 points by [gmays](user?id=gmays) [8 hours ago](item?id=42805777) \| [hide](hide?id=42805777&goto=news) \| [2 comments](item?id=42805777)  
+  
+19\. [Searching for DeepSeek's glitch tokens](https://outsidetext.substack.com/p/anomalous-tokens-in-deepseek-v3-and) \([outsidetext\.substack\.com](from?site=outsidetext.substack.com)\)  
+148 points by [arithmoquine](user?id=arithmoquine) [16 hours ago](item?id=42824473) \| [hide](hide?id=42824473&goto=news) \| [39 comments](item?id=42824473)  
+  
+20\. [An experiment of adding recommendation engine to your app using pgvector search](https://silk.us/blog/vector-search-ai-integration/) \([silk\.us](from?site=silk.us)\)  
+44 points by [tanelpoder](user?id=tanelpoder) [11 hours ago](item?id=42804406) \| [hide](hide?id=42804406&goto=news) \| [3 comments](item?id=42804406)  
+  
+21\. [Wikenigma – an Encyclopedia of Unknowns](https://wikenigma.org.uk/start) \([wikenigma\.org\.uk](from?site=wikenigma.org.uk)\)  
+134 points by [jgamman](user?id=jgamman) [15 hours ago](item?id=42824617) \| [hide](hide?id=42824617&goto=news) \| [35 comments](item?id=42824617)  
+  
+22\. [You probably don't need query builders](https://mattrighetti.com/2025/01/20/you-dont-need-sql-builders) \([mattrighetti\.com](from?site=mattrighetti.com)\)  
+111 points by [mattrighetti](user?id=mattrighetti) [17 hours ago](item?id=42778151) \| [hide](hide?id=42778151&goto=news) \| [102 comments](item?id=42778151)  
+  
+23\. [Open Heart Protocol](https://openheart.fyi/) \([openheart\.fyi](from?site=openheart.fyi)\)  
+199 points by [thunderbong](user?id=thunderbong) [21 hours ago](item?id=42791378) \| [hide](hide?id=42791378&goto=news) \| [84 comments](item?id=42791378)  
+  
+24\. [Using AI to develop a fuller model of the human brain](https://magazine.ucsf.edu/building-a-silicon-brain) \([ucsf\.edu](from?site=ucsf.edu)\)  
+72 points by [geox](user?id=geox) [15 hours ago](item?id=42824625) \| [hide](hide?id=42824625&goto=news) \| [27 comments](item?id=42824625)  
+  
+25\. [Mastering Atari Games with Natural Intelligence](https://www.verses.ai/blog/mastering-atari-games-with-natural-intelligence) \([verses\.ai](from?site=verses.ai)\)  
+19 points by [alex\_c](user?id=alex_c) [7 hours ago](item?id=42806998) \| [hide](hide?id=42806998&goto=news) \| [7 comments](item?id=42806998)  
+  
+26\. [How far can you get in 40 minutes from each subway station in NYC?](https://subwaysheds.com/#11.27/40.7427/-73.9869) \([subwaysheds\.com](from?site=subwaysheds.com)\)  
+277 points by [jxmorris12](user?id=jxmorris12) [1 day ago](item?id=42810293) \| [hide](hide?id=42810293&goto=news) \| [168 comments](item?id=42810293)  
+  
+27\. [Ask HN: How to automate collecting HAR file while user is browsing](item?id=42817554)  
+11 points by [royalghost](user?id=royalghost) [4 hours ago](item?id=42817554) \| [hide](hide?id=42817554&goto=news) \| [9 comments](item?id=42817554)  
+  
+28\. [A FPGA friendly 32 bit RISC-V CPU implementation](https://github.com/SpinalHDL/VexRiscv) \([github\.com/spinalhdl](from?site=github.com/spinalhdl)\)  
+105 points by [\_benj](user?id=_benj) [20 hours ago](item?id=42793580) \| [hide](hide?id=42793580&goto=news) \| [48 comments](item?id=42793580)  
+  
+29\. [Using Linear Programming to find optimal builds in League of Legend](https://versary.town/blog/using-linear-programming-to-find-optimal-builds-in-league-of-legends/) \([versary\.town](from?site=versary.town)\)  
+20 points by [birdculture](user?id=birdculture) [6 hours ago](item?id=42796292) \| [hide](hide?id=42796292&goto=news) \| [7 comments](item?id=42796292)  
+  
+30\. [Immutability Changes Everything \(2016\) \[pdf\]](https://www.cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf) \([cidrdb\.org](from?site=cidrdb.org)\)  
+88 points by [fire\_lake](user?id=fire_lake) [15 hours ago](item?id=42824983) \| [hide](hide?id=42824983&goto=news) \| [29 comments](item?id=42824983)  
+  
+  
 [More](?p=2)

--- a/test-pages/alt/mozilla_readability/expected.md
+++ b/test-pages/alt/mozilla_readability/expected.md
@@ -11,7 +11,6 @@ Readability is available on npm:
 npm install @mozilla/readability
 ```
 
-
 You can then `require()` it, or for web-based projects, load the `Readability.js` script from your webpage\.
 
 ## Basic usage
@@ -22,7 +21,6 @@ To parse a document, you must create a new `Readability` object from a DOM docum
 ```
 var article = new Readability(document).parse();
 ```
-
 
 If you use Readability in a web browser, you will likely be able to use a `document` reference from elsewhere \(e\.g\. fetched via XMLHttpRequest, in a same-origin `<iframe>` you have access to, etc\.\)\. In Node\.js, you can [use an external DOM library](#nodejs-usage)\.
 
@@ -42,6 +40,7 @@ The `options` object accepts a number of properties, all optional:
 - `serializer` \(function, default `el => el.innerHTML`\) controls how the `content` property returned by the `parse()` method is produced from the root DOM element\. It may be useful to specify the `serializer` as the identity function \(`el => el`\) to obtain a DOM element instead of a string for `content` if you plan to process it further\.
 - `allowedVideoRegex` \(RegExp, default `undefined` \): a regular expression that matches video URLs that should be allowed to be included in the article content\. If `undefined`, the [default regex](https://github.com/mozilla/readability/blob/8e8ec27cd2013940bc6f3cc609de10e35a1d9d86/Readability.js#L133) is applied\.
 - `linkDensityModifier` \(number, default `0`\): a number that is added to the base link density threshold during the shadiness checks\. This can be used to penalize nodes with a high link density or vice versa\.
+
 ### `parse()`
 
 Returns an object containing the following properties:
@@ -56,6 +55,7 @@ Returns an object containing the following properties:
 - `siteName`: name of the site;
 - `lang`: content language;
 - `publishedTime`: published time;
+
 The `parse()` method works by modifying the DOM\. This removes some elements in the web page, which may be undesirable\. You can avoid this by passing the clone of the `document` object to the `Readability` constructor:
 
 
@@ -63,7 +63,6 @@ The `parse()` method works by modifying the DOM\. This removes some elements in 
 var documentClone = document.cloneNode(true);
 var article = new Readability(documentClone).parse();
 ```
-
 
 ### `isProbablyReaderable(document, options)`
 
@@ -74,6 +73,7 @@ The `options` object accepts a number of properties, all optional:
 - `minContentLength` \(number, default `140`\): the minimum node content length used to decide if the document is readerable;
 - `minScore` \(number, default `20`\): the minimum cumulated 'score' used to determine if the document is readerable;
 - `visibilityChecker` \(function, default `isNodeVisible`\): the function used to determine if a node is visible;
+
 The function returns a boolean corresponding to whether or not we suspect `Readability.parse()` will succeed at returning an article object\. Here's an example:
 
 
@@ -86,7 +86,6 @@ if (isProbablyReaderable(document)) {
     let article = new Readability(document).parse();
 }
 ```
-
 
 ## Node\.js usage
 
@@ -102,7 +101,6 @@ var doc = new JSDOM("<body>Look at this cat: <img src='./cat.jpg'></body>", {
 let reader = new Readability(doc.window.document);
 let article = reader.parse();
 ```
-
 
 Remember to pass the page's URI as the `url` option in the `JSDOM` constructor \(as shown in the example above\), so that Readability can convert relative URLs for images, hyperlinks, etc\. to their absolute counterparts\.
 

--- a/test-pages/alt/rust-blog/expected.md
+++ b/test-pages/alt/rust-blog/expected.md
@@ -7,6 +7,7 @@ If you have a previous version of Rust installed via `rustup`, you can get 1\.84
 $ rustup update stable
 
 ```
+
 If you don't have it already, you can [get rustup](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1\.84\.0](https://doc.rust-lang.org/stable/releases.html#version-1840-2025-01-09)\.
 
 If you'd like to help us out by testing future releases, you might consider updating locally to use the beta channel \(`rustup default beta`\) or the nightly channel \(`rustup default nightly`\)\. Please [report](https://github.com/rust-lang/rust/issues/new/choose) any bugs you might come across\!
@@ -25,6 +26,7 @@ You can opt-in to the MSRV-aware resolver via [\.cargo/config\.toml](https://doc
 incompatible-rust-versions = "fallback"
 
 ```
+
 Then when adding a dependency:
 
 
@@ -38,6 +40,7 @@ warning: ignoring clap@4.5.23 (which requires rustc 1.74) to maintain demo's rus
       Adding clap v4.0.32 (available: v4.5.23, requires Rust 1.74)
 
 ```
+
 When [verifying the latest dependencies in CI](https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-latest-dependencies), you can override this:
 
 
@@ -48,6 +51,7 @@ $ CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=allow cargo update
     Updating clap v4.0.32 -> v4.5.23
 
 ```
+
 You can also opt-in by setting [package\.resolver = "3"](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) in the Cargo\.toml manifest file though that will require raising your MSRV to 1\.84\. The new resolver will be enabled by default for projects using the 2024 edition \(which will stabilize in 1\.85\)\.
 
 This gives library authors more flexibility when deciding their policy on adopting new Rust toolchain features\. Previously, a library adopting features from a new Rust toolchain would force downstream users of that library who have an older Rust version to either upgrade their toolchain or manually select an old version of the library compatible with their toolchain \(and avoid running `cargo update`\)\. Now, those users will be able to automatically use older library versions compatible with their older toolchain\.
@@ -91,6 +95,7 @@ For more details, see the standard library [documentation on provenance](https:/
 - [core::ptr::dangling](https://doc.rust-lang.org/stable/core/ptr/fn.dangling.html)
 - [core::ptr::dangling\_mut](https://doc.rust-lang.org/stable/core/ptr/fn.dangling_mut.html)
 - [Pin::as\_deref\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.as_deref_mut)
+
 These APIs are now stable in const contexts
 
 - [AtomicBool::from\_ptr](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicBool.html#method.from_ptr)
@@ -116,6 +121,7 @@ These APIs are now stable in const contexts
 - [Pin::get\_unchecked\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.get_unchecked_mut)
 - [Pin::static\_ref](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.static_ref)
 - [Pin::static\_mut](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.static_mut)
+
 ### Other changes
 
 Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.84.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-184-2025-01-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-184)\.

--- a/test-pages/readability/arxiv/expected.md
+++ b/test-pages/readability/arxiv/expected.md
@@ -18,5 +18,5 @@ Authors:[Hamed Firooz](https://arxiv.org/search/cs?searchtype=author&query=Firoo
 
 ## Submission history
 
-From: Maziar Sanjabi \[[view email](/show-email/fa91fd8b/2501.16450)\]
+From: Maziar Sanjabi \[[view email](/show-email/fa91fd8b/2501.16450)\]  
 **\[v1\]** Mon, 27 Jan 2025 19:14:52 UTC \(1,931 KB\)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency to dom_query 0.23.0.
  - Updated changelog to reflect the change.
- Documentation
  - Refreshed sample page content/formatting: numbered Hacker News list, spacing tweaks in readability pages, expanded Rust blog sections, and clearer arXiv submission history metadata.
- Tests
  - Updated expected outputs for sample pages to align with the new formatting and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->