### PR TITLE
Revise link density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ## [Unreleased]
 ### Changed
 - Updated `dom_query` version from `0.22.0` to `0.23.0`.
-
+- Revised `grab::score_elements`: use a cache for normalized char count to improve performance. No public API changes.
 
 ### Fixed
 - `MATCHER_LAZY_IMG` is now used in `prep_article::fix_lazy_images` instead of `MINI_LAZY`, since the latter does not support complex selectors.

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -360,7 +360,7 @@ fn score_elements<'a>(
         }
     }
 
-    let mut density_cache = CharCounter::new();
+    let mut cc_cache = CharCounterCache::default();
 
     // Scale the final candidates score based on link density. Good content
     // should have a relatively small link density (5% or less) and be mostly
@@ -373,7 +373,7 @@ fn score_elements<'a>(
             let candidate = NodeRef::new(node_id, tree);
             // Skipping adjustment of low score
             let score = if prev_score > cfg.min_score_to_adjust {
-                prev_score * (1.0 - density_cache.link_density(&candidate, None))
+                prev_score * (1.0 - link_density_fn(&candidate, None, |n| cc_cache.char_count(n)))
             } else {
                 prev_score
             };

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -360,6 +360,8 @@ fn score_elements<'a>(
         }
     }
 
+    let mut density_cache = CharCounter::new();
+
     // Scale the final candidates score based on link density. Good content
     // should have a relatively small link density (5% or less) and be mostly
     // unaffected by this operation.
@@ -371,7 +373,7 @@ fn score_elements<'a>(
             let candidate = NodeRef::new(node_id, tree);
             // Skipping adjustment of low score
             let score = if prev_score > cfg.min_score_to_adjust {
-                prev_score * (1.0 - link_density(&candidate, None))
+                prev_score * (1.0 - density_cache.link_density(&candidate, None))
             } else {
                 prev_score
             };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
+use foldhash::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 
-use dom_query::{Node, Selection};
+use dom_query::{Node, NodeId, Selection};
 
 use crate::glob::*;
 use crate::matching::*;
@@ -194,6 +195,48 @@ pub(crate) fn is_probably_visible(node: &Node) -> bool {
         return false;
     }
     !MINI_ARIA_HIDDEN.match_node(node) || MINI_FALLBACK_IMG.match_node(node)
+}
+
+pub (crate) struct CharCounter {
+    inner: HashMap<NodeId, usize>
+}
+
+impl CharCounter {
+    pub fn new() -> Self {
+        CharCounter { inner: HashMap::default() }
+    }
+}
+
+impl CharCounter {
+    pub (crate) fn normalized_char_count(&mut self, node: &Node) -> usize {
+        *self.inner.entry(node.id).or_insert_with(|| node.normalized_char_count())
+    }
+
+
+    pub(crate) fn link_density(&mut self, node: &Node, char_count: Option<usize>) -> f32 {
+    let mut link_length = 0f32;
+
+    for a in node.find_descendants("a") {
+        let href = a.attr_or("href", "");
+        let coeff = if href.len() > 1 && href.starts_with('#') {
+            0.3
+        } else {
+            1.0
+        };
+        link_length += self.normalized_char_count(&a) as f32 * coeff;
+    }
+
+    if link_length == 0.0 {
+        return 0.0;
+    }
+
+    let text_length = char_count.unwrap_or_else(|| self.normalized_char_count(&node)) as f32;
+    if text_length == 0.0 {
+        return 0.0;
+    }
+
+    link_length / text_length
+}
 }
 
 #[cfg(test)]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -214,29 +214,29 @@ impl CharCounter {
 
 
     pub(crate) fn link_density(&mut self, node: &Node, char_count: Option<usize>) -> f32 {
-    let mut link_length = 0f32;
+        let mut link_length = 0f32;
 
-    for a in node.find_descendants("a") {
-        let href = a.attr_or("href", "");
-        let coeff = if href.len() > 1 && href.starts_with('#') {
-            0.3
-        } else {
-            1.0
-        };
-        link_length += self.normalized_char_count(&a) as f32 * coeff;
+        for a in node.find_descendants("a") {
+            let href = a.attr_or("href", "");
+            let coeff = if href.len() > 1 && href.starts_with('#') {
+                0.3
+            } else {
+                1.0
+            };
+            link_length += self.normalized_char_count(&a) as f32 * coeff;
+        }
+
+        if link_length == 0.0 {
+            return 0.0;
+        }
+
+        let text_length = char_count.unwrap_or_else(|| self.normalized_char_count(&node)) as f32;
+        if text_length == 0.0 {
+            return 0.0;
+        }
+
+        link_length / text_length
     }
-
-    if link_length == 0.0 {
-        return 0.0;
-    }
-
-    let text_length = char_count.unwrap_or_else(|| self.normalized_char_count(&node)) as f32;
-    if text_length == 0.0 {
-        return 0.0;
-    }
-
-    link_length / text_length
-}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Revised `grab::score_elements`: use a cache for normalized char count to improve performance. No public API changes.
