### PR TITLE
fixed a panic, when parsing a  fragment (without a <body>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Breaking**: Fixed a panic when `Readability::with_document` was used with a `dom_query::Document` created via `dom_query::Document::fragment`, where `<body>` is unreachable. 
+In this case, `Readability::parse` now returns `ReadabilityError::GrabFailed`.
+
 ## [0.14.0] - 2025-12-01
 
 ### Added

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -69,7 +69,6 @@ impl Readability {
         flags: &FlagSet<GrabFlags>,
     ) -> Option<NodeRef<'a>> {
         let selection = doc.select_single("body");
-        // html5ever always puts body element, even if it wasn't in the document's contents
         let body_node = selection.nodes().first()?;
         let strip_unlikely = flags.contains(GrabFlags::StripUnlikelys);
         let mut elements_to_score = collect_elements_to_score(body_node, strip_unlikely);
@@ -165,8 +164,9 @@ pub(crate) fn pre_filter_document(doc: &Document, metadata: &mut Metadata) {
     // However, I believe it is better to do it only once. Additionally, there is a lot of logic that relies
     // on a certain element which is going to be removed in the next iteration.
     let body_sel = doc.select_single("body");
-    // html5ever always puts body element, even if it wasn't in the document's contents
-    let body_node = body_sel.nodes().first().unwrap();
+    let Some(body_node) = body_sel.nodes().first() else {
+        return;
+    };
     let mut should_remove_title_header = !metadata.title.is_empty();
     let mut next_node = next_child_or_sibling(body_node, false);
     while let Some(node) = next_node {

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -46,3 +46,26 @@ fn test_skip_body_ancestor_fragment() {
     let got: String = res.content.split_whitespace().collect();
     assert_eq!(got, expected);
 }
+
+#[test]
+fn test_fragments() {
+    let contents_0 = r#"
+    <body>
+        <p><a class="button" href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+    </body>
+    "#;
+
+    let contents_1 = r#"
+        <p><a class="button" href="https://example.com/sign-up"> Sign Up for Live Updates!</a></p>
+    "#;
+
+    let cases = vec![contents_0, contents_1];
+
+    for contents in cases {
+        let doc = dom_query::Document::fragment(contents);
+
+        let mut ra = Readability::with_document(doc, None, None).unwrap();
+        let err = ra.parse().unwrap_err();
+        assert!(matches!(err, dom_smoothie::ReadabilityError::GrabFailed));
+    }
+}


### PR DESCRIPTION

- **Breaking**: Fixed a panic when `Readability::with_document` was used with a `dom_query::Document` created via `dom_query::Document::fragment`, where `<body>` is unreachable. 
In this case, `Readability::parse` now returns `ReadabilityError::GrabFailed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a panic that occurred when parsing certain document types. The parser now returns an error instead of panicking when the document structure lacks required elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->