### PR TITLE
feat(cli): add stdin/stdout support for pipeline usage

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,34 +1,65 @@
 //! This is a reference implementation of a CLI tool for the `dom_smoothie` crate.
 //!
 //! The tool processes an HTML document using [`dom_smoothie::Readability`] to extract
-//! relevant content and metadata. It accepts an input HTML file and outputs the
+//! relevant content and metadata. It accepts an input HTML file (or stdin) and outputs the
 //! parsed article content as both HTML and plain text, along with metadata in JSON format.
 //!
 //! ## Usage
 //! ```bash
+//! # File input, file output (default)
 //! dom_smoothie_cli --input path/to/input.html --output path/to/output/dir
+//!
+//! # Stdin to stdout
+//! cat page.html | dom_smoothie_cli
+//!
+//! # Stdin, select text output
+//! curl -s https://example.com | dom_smoothie_cli -f text
+//!
+//! # File input, stdout
+//! dom_smoothie_cli --input page.html --stdout -f metadata
 //! ```
 //!
-//! If the `--output` argument is omitted, the results will be saved in the same directory
-//! as the input file. An optional `--document-url` parameter can be provided to enhance
-//! parsing accuracy by specifying the base document URL.
+//! If the `--input` argument is omitted (or set to `-`), input is read from stdin.
+//! When reading from stdin with no `--output` specified, results are printed to stdout.
+//! If the `--output` argument is omitted with file input, the results will be saved in the
+//! same directory as the input file. An optional `--document-url` parameter can be provided
+//! to enhance parsing accuracy by specifying the base document URL.
 
 use std::error::Error;
+use std::ffi::OsString;
+use std::io::{self, IsTerminal, Read, Write};
 use std::{fs, path::PathBuf};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use dom_smoothie::{Article, CandidateSelectMode, Config, Readability, TextMode};
+
+#[derive(Clone, ValueEnum)]
+enum OutputFormat {
+    /// Extracted article HTML
+    Html,
+    /// Extracted plain text content
+    Text,
+    /// Article metadata as JSON
+    Metadata,
+}
 
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]
 #[clap(help_template = "{name} {version}\n\n{about}\n\n{usage}\n\n{all-args}")]
 struct Cli {
-    /// Sets an input path to the html document
+    /// Sets an input path to the html document. Omit or use `-` to read from stdin.
     #[clap(short, long, value_parser)]
-    input: PathBuf,
+    input: Option<PathBuf>,
     /// Sets an output path. If omitted the parent dir of `<INPUT>` will be used.
+    /// When reading from stdin, omitting this enables stdout mode.
     #[clap(short, long, value_parser)]
     output: Option<PathBuf>,
+    /// Print output to stdout instead of writing files
+    #[clap(long, value_parser)]
+    stdout: bool,
+    /// Output format when writing to stdout (html, text, or metadata)
+    #[clap(short = 'f', long, value_enum, default_value = "html")]
+    output_format: OutputFormat,
     /// Sets an optional base document URL
     #[clap(short, long, value_parser, value_name = "URL")]
     document_url: Option<String>,
@@ -89,20 +120,42 @@ impl From<&Article> for Metadata {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let mut cli = Cli::parse();
-
-    let input_path_buf = cli.input.with_extension("");
-    let Some(input_fn) = input_path_buf.file_name() else {
-        return Err("invalid input path".into());
-    };
-
-    if cli.output.is_none() {
-        cli.output = input_path_buf.parent().map(|p| p.to_path_buf());
+/// Reads HTML content from either a file or stdin.
+/// Returns the content string and an optional source name (file stem).
+fn read_input(input: &Option<PathBuf>) -> Result<(String, Option<OsString>), Box<dyn Error>> {
+    match input {
+        Some(path) if path.as_os_str() != "-" => {
+            let source_name = path.with_extension("").file_name().map(|n| n.to_owned());
+            let contents = fs::read_to_string(path)?;
+            Ok((contents, source_name))
+        }
+        _ => {
+            let stdin = io::stdin();
+            if stdin.is_terminal() {
+                eprintln!(
+                    "Warning: reading from terminal stdin. \
+                     Did you mean to pipe input? Press Ctrl+D when done."
+                );
+            }
+            let mut contents = String::new();
+            stdin.lock().read_to_string(&mut contents)?;
+            Ok((contents, None))
+        }
     }
+}
 
-    let contents = fs::read_to_string(cli.input)?;
+fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+
+    // Read input from file or stdin
+    let (contents, source_name) = read_input(&cli.input)?;
     let document_url = cli.document_url.as_deref();
+
+    // Determine if we're in stdout mode:
+    // explicitly via --stdout, or implicitly when input is stdin and no --output given
+    let is_stdin =
+        cli.input.is_none() || cli.input.as_deref() == Some(std::path::Path::new("-"));
+    let use_stdout = cli.stdout || (is_stdin && cli.output.is_none());
 
     let text_mode = if cli.formatted_text {
         TextMode::Formatted
@@ -131,30 +184,44 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut ra = Readability::new(contents, document_url, Some(cfg))?;
     let article = ra.parse()?;
 
-    let Some(output_path) = cli.output else {
-        unreachable!();
-    };
+    if use_stdout {
+        let mut stdout = io::stdout().lock();
+        match cli.output_format {
+            OutputFormat::Html => {
+                write!(stdout, "{}", article.content)?;
+            }
+            OutputFormat::Text => {
+                write!(stdout, "{}", article.text_content)?;
+            }
+            OutputFormat::Metadata => {
+                let metadata = Metadata::from(&article);
+                let metadata_content = serde_json::to_string_pretty(&metadata)?;
+                write!(stdout, "{}", metadata_content)?;
+            }
+        }
+    } else {
+        // File output mode
+        let base_name = source_name.unwrap_or_else(|| OsString::from("stdin"));
+        let base_name_str = base_name.to_string_lossy();
 
-    let result_html_path: PathBuf = output_path
-        .clone()
-        .join(format!("{}_result.html", input_fn.to_string_lossy()));
+        let output_path = cli.output.unwrap_or_else(|| {
+            cli.input
+                .as_ref()
+                .and_then(|p| p.with_extension("").parent().map(|par| par.to_path_buf()))
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
 
-    fs::write(result_html_path, article.content.as_bytes())?;
+        let result_html_path = output_path.join(format!("{base_name_str}_result.html"));
+        fs::write(result_html_path, article.content.as_bytes())?;
 
-    let result_text_path: PathBuf = output_path
-        .clone()
-        .join(format!("{}_result.txt", input_fn.to_string_lossy()));
+        let result_text_path = output_path.join(format!("{base_name_str}_result.txt"));
+        fs::write(result_text_path, article.text_content.as_bytes())?;
 
-    fs::write(result_text_path, article.text_content.as_bytes())?;
-
-    let metadata = Metadata::from(&article);
-    let metadata_content = serde_json::to_string_pretty(&metadata)?;
-
-    let meta_path: PathBuf = output_path
-        .clone()
-        .join(format!("{}_metadata.json", input_fn.to_string_lossy()));
-
-    fs::write(meta_path, metadata_content)?;
+        let metadata = Metadata::from(&article);
+        let metadata_content = serde_json::to_string_pretty(&metadata)?;
+        let meta_path = output_path.join(format!("{base_name_str}_metadata.json"));
+        fs::write(meta_path, metadata_content)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- Make --input optional; omit or use '-' to read from stdin
- Add --stdout flag to print output to stdout instead of files
- Add -f/--output-format option (html, text, metadata) for stdout
- Auto-enable stdout mode when input is stdin with no --output
- Warn when reading from a terminal (no pipe) on stdin
- Preserve full backward compatibility with file-based workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* CLI now accepts HTML input from either a file or stdin
* Added `--stdout` flag to output results directly to stdout
* New `--output-format` option supports HTML, text, or metadata formats
* File output mode generates three separate result files with different formats
* Enhanced input handling with improved stdin detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->