### PR TITLE
chore: bump version 0.18.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
-## [Unreleased]
+## [0.18.0] - 2026-06-07
 
 ### Added
 - **cli**: added stdin/stdout support for pipeline usage (by @dflock).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "dom-smoothie-bench"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "dom_smoothie",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "dom-smoothie-js"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "console_error_panic_hook",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "dom-smoothie-lua"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "dom_smoothie",
  "mlua",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "dom_smoothie"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aho-corasick",
  "dom_query",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "dom_smoothie_cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "dom_smoothie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version 0.18.0 released on June 7, 2026; changelog updated to mark the new release.
  * CI tooling updated to a newer Codecov uploader to keep coverage reporting current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->