### PR TITLE
fix: break candidate score ties by first-scored order, not hash-map order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 ### Changed
 - Refactored the internal `score_elements` function.
 
+### Fixed
+- `score_elements` breaks score ties by the order candidates were first scored (mozilla/readability's `candidates` array) instead of the hash map's per-process iteration order, so the same document yields the same article in every process.
+
 ## [0.18.0] - 2026-06-07
 
 ### Added

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -233,6 +233,11 @@ fn score_elements<'a>(
     flags: &FlagSet<GrabFlags>,
 ) -> Vec<NodeRef<'a>> {
     let mut score_map: HashMap<NodeId, f32> = HashMap::default();
+    // The order candidates were first scored -- mozilla/readability's
+    // `candidates` array. The stable sort below breaks score ties by this
+    // order, never by the hash map's (randomly seeded, per-process) iteration
+    // order, so the same document yields the same top candidate in every run.
+    let mut candidate_order: Vec<NodeId> = Vec::new();
     let mut cc_cache = CharCounterCache::default();
 
     for element in elements_to_score {
@@ -263,6 +268,7 @@ fn score_elements<'a>(
                 .entry(ancestor.id)
                 .and_modify(|e| *e += extra_score)
                 .or_insert_with(|| {
+                    candidate_order.push(ancestor.id);
                     extra_score
                         + determine_node_score(ancestor, flags.contains(GrabFlags::WeightClasses))
                 });
@@ -277,8 +283,9 @@ fn score_elements<'a>(
     // should have a relatively small link density (5% or less) and be mostly
     // unaffected by this operation.
 
-    let mut scored_candidates: Vec<_> = score_map
+    let mut scored_candidates: Vec<_> = candidate_order
         .into_iter()
+        .filter_map(|node_id| score_map.get(&node_id).map(|score| (node_id, *score)))
         .filter(|(_, score)| *score > 0.0)
         .map(|(node_id, base_score)| {
             let candidate = NodeRef::new(node_id, tree);
@@ -637,6 +644,37 @@ mod tests {
 
     use super::*;
     use crate::readability::Readability;
+
+    /// Candidates with equal scores keep the order they were first scored in
+    /// (mozilla/readability's `candidates` array). Before this test the stable
+    /// sort broke ties by the hash map's per-process iteration order, so the
+    /// same document could pick a different top candidate from one run to the
+    /// next (measured on a real page: two different articles across 40 runs).
+    #[test]
+    fn test_equal_score_candidates_keep_their_first_scored_order() {
+        // Two paragraphs per div: a div holding a single <p> is folded into
+        // that <p> before scoring (`div_into_p`) and would not be a candidate.
+        let block = "<p>Seven words, with two commas, and enough characters to score.</p>\
+                     <p>Another line, with two commas, and enough characters to score.</p>";
+        let contents = format!(
+            "<!DOCTYPE html><html><head><title>Test</title></head><body>\
+             <div id=\"a\">{block}</div><div id=\"b\">{block}</div>\
+             <div id=\"c\">{block}</div><div id=\"d\">{block}</div>\
+             </body></html>"
+        );
+        let doc = Document::from(contents.as_str());
+        let body = doc.body().unwrap();
+        let elements = collect_elements_to_score(&body, true, &Metadata::default());
+        let cfg = Config::default();
+        let flags: FlagSet<GrabFlags> = FlagSet::full();
+        let top = score_elements(&elements, body.tree, &cfg, &flags);
+        let divs: Vec<String> = top
+            .iter()
+            .map(|n| n.attr_or("id", "").to_string())
+            .filter(|id| !id.is_empty())
+            .collect();
+        assert_eq!(divs, ["a", "b", "c", "d"]);
+    }
 
     #[test]
     fn test_removing_probably_invisible_nodes() {


### PR DESCRIPTION
## Problem

`score_elements` collects the scored candidates out of a `foldhash::HashMap<NodeId, f32>` and then stable-sorts them by score. `foldhash`'s global seed is mixed from process addresses (ASLR), so the map's iteration order differs from one process to the next; two candidates with **equal** scores therefore come out in a different order per process, and `top_candidates.first()` — the article — changes with them.

Measured on one real page (a forum thread from the WCXB dev split): 40 identical runs of the same binary on the same bytes produced two different articles, 30 runs a 529-character extraction and 10 runs a 326-character one. Over a 1497-page corpus, 20 runs disagreed on 2 pages (one of them with three distinct outputs).

## Fix

Keep the order candidates were first scored in — the order of mozilla/readability's `candidates` array, where a later candidate only displaces an earlier one with a strictly greater score — and build `scored_candidates` from that order instead of `score_map.into_iter()`. The stable sort then breaks ties by first-scored order, never by the map's. Scores are unchanged (the same `entry` arithmetic; only the collection order moves).

## Test

`test_equal_score_candidates_keep_their_first_scored_order`: four `<div>` blocks of identical shape (equal scores) must come out in document order. Without the change the assertion holds one run in twenty-four; with it, always. The existing suite passes unchanged (43 + integration tests).

Measured after the change on the same corpus: 20 runs × 1497 pages agree byte for byte; the extraction F1 against the corpus's ground truth is unchanged (0.7796 → 0.7797 on 1497 pages; 0.8225 → 0.8225 on 511 held-out pages).

## Notes

- Base: `main` (`e930ae8`, the entry-API refactor of `score_elements`).
- `CHANGELOG.md`: one line under `[Unreleased] / Fixed`.
- Signed-off-by per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed inconsistent article selection when candidate elements receive equal scores.
  - Equal-scoring candidates now follow their document scoring order, producing consistent results across runs.

- **Documentation**
  - Added an unreleased changelog entry describing the deterministic selection fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->