### PR TITLE
shorten the comments related to `score_elements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the `dom_smoothie` crate will be documented in this file.
 - Refactored the internal `score_elements` function.
 
 ### Fixed
-- `score_elements` breaks score ties by the order candidates were first scored (mozilla/readability's `candidates` array) instead of the hash map's per-process iteration order, so the same document yields the same article in every process.
+- Candidate tie-breaking order in `score_elements` when scores are tied (by @ThibautMelen).
 
 ## [0.18.0] - 2026-06-07
 

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -233,10 +233,7 @@ fn score_elements<'a>(
     flags: &FlagSet<GrabFlags>,
 ) -> Vec<NodeRef<'a>> {
     let mut score_map: HashMap<NodeId, f32> = HashMap::default();
-    // The order candidates were first scored -- mozilla/readability's
-    // `candidates` array. The stable sort below breaks score ties by this
-    // order, never by the hash map's (randomly seeded, per-process) iteration
-    // order, so the same document yields the same top candidate in every run.
+    // Preserves the initial order of candidates to ensure deterministic tie-breaking.
     let mut candidate_order: Vec<NodeId> = Vec::new();
     let mut cc_cache = CharCounterCache::default();
 
@@ -645,11 +642,7 @@ mod tests {
     use super::*;
     use crate::readability::Readability;
 
-    /// Candidates with equal scores keep the order they were first scored in
-    /// (mozilla/readability's `candidates` array). Before this test the stable
-    /// sort broke ties by the hash map's per-process iteration order, so the
-    /// same document could pick a different top candidate from one run to the
-    /// next (measured on a real page: two different articles across 40 runs).
+    /// Ensures candidates with equal scores preserve their order to keep ranking deterministic.
     #[test]
     fn test_equal_score_candidates_keep_their_first_scored_order() {
         // Two paragraphs per div: a div holding a single <p> is folded into

--- a/src/readability.rs
+++ b/src/readability.rs
@@ -393,15 +393,15 @@ impl Readability {
                 continue;
             };
             let prev_sel = Selection::from(prev_sibling);
-            let prev_img: NodeRef;
-            if prev_sel.is("img") {
-                prev_img = prev_sibling;
+            
+            let prev_img: NodeRef = if prev_sel.is("img") {
+                prev_sibling
             } else if prev_sel.is("*:has( > img:only-child)") {
                 let prev_sel_img = prev_sel.select("img:only-child");
-                prev_img = prev_sel_img.nodes()[0];
+                prev_sel_img.nodes()[0]
             } else {
                 continue;
-            }
+            };
             let noscript_img_sel = Selection::from(*noscript_node).select("img");
             // at this point noscript_img_sel always has one element
             let new_img = &noscript_img_sel.nodes()[0];


### PR DESCRIPTION
- simplify comments related to `score_elements` from #213
- Apply `clippy` suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified candidate tie-breaking behavior when scores are equal, including the ordering used to select results.
  - Updated related test documentation to better describe expected ordering.

- **Refactor**
  - Simplified internal image-processing control flow without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->