### PR TITLE
chore: bump version 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the `dom_smoothie` crate will be documented in this file.
 
-## [Unreleased]
+## [0.18.1] - 2026-09-07
 
 ### Changed
 - Refactored the internal `score_elements` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version to 0.18.1.
  - Published the 0.18.1 changelog entry dated September 7, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->